### PR TITLE
fix: handle invalid regex in excluded apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Package extension
         id: package
-        uses: murar8/gnome-extensions-action@0.1.0
+        uses: murar8/gnome-extensions-action@0.1.1
         if: github.ref_type != 'tag'
         with:
           source-dir: dist
@@ -65,7 +65,7 @@ jobs:
       - name: Package and upload extension
         id: upload
         if: github.event_name == 'push' && github.ref_type == 'tag'
-        uses: murar8/gnome-extensions-action@0.1.0
+        uses: murar8/gnome-extensions-action@0.1.1
         with:
           source-dir: dist
           extra-source: |

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,14 @@ function getObjectLabel(name: string, values: Record<string, string | null>) {
   return `${name}(${labels.join(", ")})`;
 }
 
+function safeRegexTest(pattern: string, value: string): boolean | null {
+  try {
+    return new RegExp(pattern).test(value);
+  } catch {
+    return null;
+  }
+}
+
 function getWindowLabel(window: Meta.Window) {
   return getObjectLabel("Window", {
     ["Title"]: window.title,
@@ -62,7 +70,13 @@ export default class JunkNotificationCleaner extends Extension {
 
     const excludedApps = this.settings!.get_strv("excluded-apps");
     for (const wmClassPattern of excludedApps) {
-      if (new RegExp(wmClassPattern).test(window.wmClass)) {
+      const result = safeRegexTest(wmClassPattern, window.wmClass);
+      if (result === null) {
+        this.log(
+          LogLevel.WARN,
+          `${windowLabel}: invalid regex '${wmClassPattern}'`,
+        );
+      } else if (result) {
         this.log(
           LogLevel.DEBUG,
           `${windowLabel}: excluded by '${wmClassPattern}'`,
@@ -112,9 +126,11 @@ export default class JunkNotificationCleaner extends Extension {
   disable() {
     if (this.focusListenerId !== null) {
       global.display.disconnect(this.focusListenerId);
+      this.focusListenerId = null;
     }
     if (this.closeListenerId !== null) {
       global.window_manager.disconnect(this.closeListenerId);
+      this.closeListenerId = null;
     }
     if (this.settings) {
       this.settings = null;

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -6,6 +6,15 @@ import type { LogLevel } from "./extension.js";
 
 const LOG_LEVELS: LogLevel[] = ["debug", "info", "warn", "error"] as LogLevel[];
 
+function isValidRegex(pattern: string): boolean {
+  try {
+    new RegExp(pattern);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export default class JunkNotificationCleanerPreferences extends ExtensionPreferences {
   async fillPreferencesWindow(window: Adw.PreferencesWindow) {
     const settings = this.getSettings();
@@ -123,25 +132,45 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
       hexpand: true,
     });
 
+    const errorLabel = new Gtk.Label({
+      label: "Invalid regular expression",
+      css_classes: ["error"],
+      xalign: 0,
+      visible: false,
+    });
+
     const addButton = new Gtk.Button({
       label: "Add",
       css_classes: ["suggested-action"],
     });
 
+    entry.connect("changed", () => {
+      entry.remove_css_class("error");
+      errorLabel.set_visible(false);
+    });
+
     addButton.connect("clicked", () => {
       const text = entry.get_text().trim();
       if (!text) return;
-      const currentApps = settings.get_strv("excluded-apps");
-      if (currentApps.includes(text)) return;
-      settings.set_strv("excluded-apps", [...currentApps, text]);
-      this.addExcludedAppRow(text, listBox, settings);
-      entry.set_text("");
+      if (!isValidRegex(text)) {
+        entry.add_css_class("error");
+        errorLabel.set_visible(true);
+      } else {
+        entry.remove_css_class("error");
+        errorLabel.set_visible(false);
+        const currentApps = settings.get_strv("excluded-apps");
+        if (currentApps.includes(text)) return;
+        settings.set_strv("excluded-apps", [...currentApps, text]);
+        this.addExcludedAppRow(text, listBox, settings);
+        entry.set_text("");
+      }
     });
 
     addBox.append(entry);
     addBox.append(addButton);
 
     excludedBox.append(addBox);
+    excludedBox.append(errorLabel);
     excludedGroup.add(excludedBox);
   }
 

--- a/test/extension.spec.ts
+++ b/test/extension.spec.ts
@@ -57,7 +57,6 @@ beforeEach(() => {
 
 describe(JunkNotificationCleaner.prototype.enable.name, () => {
   it("should connect to display and window_manager", () => {
-    vi.mocked(Extension.prototype.getSettings);
     extension.enable();
     expect(global.display.connect).toHaveBeenCalledTimes(1);
     expect(global.display.connect).toHaveBeenCalledWith(
@@ -312,6 +311,38 @@ it.each([
     );
   },
 );
+
+it("should log warning and continue for invalid excluded app regex", () => {
+  extension.enable();
+  settings.get_boolean.mockReturnValueOnce(true);
+  settings.get_strv.mockReturnValueOnce(["[invalid", "com\\.app\\.test"]);
+  vi.mocked(messageTray.getSources).mockReturnValueOnce([]);
+
+  const onFocusWindow = vi.mocked(global.display.connect).mock.calls[0][1];
+  const focusWindow = {
+    title: "Test",
+    wmClass: "com.app.test",
+    get_sandboxed_app_id: () => null,
+    gtkApplicationId: null,
+  } as Meta.Window;
+  const display = { focusWindow } as Meta.Display;
+  onFocusWindow(display);
+
+  expect(messageTray.getSources).not.toHaveBeenCalled();
+  expect(log).toHaveBeenCalledTimes(3);
+  expect(log).toHaveBeenNthCalledWith(
+    1,
+    "[uuid][debug] Window(Title: 'Test', WMClass: 'com.app.test'): received focus",
+  );
+  expect(log).toHaveBeenNthCalledWith(
+    2,
+    "[uuid][warn] Window(Title: 'Test', WMClass: 'com.app.test'): invalid regex '[invalid'",
+  );
+  expect(log).toHaveBeenNthCalledWith(
+    3,
+    "[uuid][debug] Window(Title: 'Test', WMClass: 'com.app.test'): excluded by 'com\\.app\\.test'",
+  );
+});
 
 it("should not clear notifications for app on focus if not enabled", () => {
   extension.enable();


### PR DESCRIPTION
Invalid regex patterns in excluded apps settings could crash the extension.
Now logs a warning and skips invalid patterns. The prefs UI validates regex
before saving and shows an error label. Also nulls out signal handler IDs
in disable() to prevent double-disconnect.
