### PR TITLE
Add shell version 50 to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Junk Notification Cleaner",
   "description": "Delete notifications for an application when its window is focused or closed.",
   "uuid": "junk-notification-cleaner@murar8.github.com",
-  "shell-version": ["46", "47", "48", "49"],
+  "shell-version": ["46", "47", "48", "49", "50"],
   "settings-schema": "org.gnome.shell.extensions.junk-notification-cleaner",
   "url": "https://github.com/murar8/junk-notification-cleaner"
 }


### PR DESCRIPTION
I've added version 50 to the metadata file and tested locally and extension works now with gnome-shell 50
