### PR TITLE
fix: restore icon/title matching heuristics for generic-policy sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-node_modules/
-schemas/*.compiled
 *.js
-*.zip
 *.tsbuildinfo
+*.zip
+.direnv/
+.envrc
 coverage/
 dist/
+node_modules/
+schemas/*.compiled

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A GNOME Shell extension that automatically deletes notifications for an applicat
 
 - Automatically delete notifications when an application window is focused.
 - Automatically delete notifications when an application window is closed.
-- Exclude specific applications from automatic notification cleanup using regex patterns.
+- Exclude specific applications from automatic notification cleanup.
 
 ## Preferences
 
@@ -20,7 +20,7 @@ gnome-extensions prefs junk-notification-cleaner@murar8.github.com
 
 - **Delete on focus**: Enable/disable notification deletion when an application window is focused.
 - **Delete on close**: Enable/disable notification deletion when an application window is closed.
-- **Excluded Applications**: Regex patterns for application WM_CLASS values that should be excluded from automatic notification cleanup.
+- **Excluded Applications**: Pick applications (by desktop id) to skip during automatic notification cleanup.
 - **Log Level**: Set the logging level (debug, info, warn, error) for troubleshooting notification matching.
 
 ## Installation

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import prettier from "eslint-config-prettier";
@@ -20,6 +21,17 @@ export default defineConfig(
         projectService: true,
         tsconfigRootDir: import.meta.dirname,
       },
+    },
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "TSAsExpression > TSUnknownKeyword, TSTypeAssertion > TSUnknownKeyword",
+          message:
+            "Avoid `as unknown` double-casts; widen the source type or add a typed helper instead.",
+        },
+      ],
     },
   },
   {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778430510,
+        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "junk-notification-cleaner dev shell";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system}; in {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            nodejs_24
+            glib            # glib-compile-schemas
+            gnome-shell     # gnome-extensions CLI
+            zip
+          ];
+        };
+      });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@eslint/js": "^10.0.1",
         "@girs/gjs": "^4.0.0-rc.9",
         "@girs/gnome-shell": "^50.0.0",
+        "@types/node": "^25.8.0",
         "@vitest/coverage-v8": "^4.1.5",
         "@vitest/eslint-plugin": "^1.6.16",
         "eslint": "^10.3.0",
@@ -1425,15 +1426,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3624,13 +3623,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@eslint/js": "^10.0.1",
     "@girs/gjs": "^4.0.0-rc.9",
     "@girs/gnome-shell": "^50.0.0",
+    "@types/node": "^25.8.0",
     "@vitest/coverage-v8": "^4.1.5",
     "@vitest/eslint-plugin": "^1.6.16",
     "eslint": "^10.3.0",

--- a/schemas/org.gnome.shell.extensions.junk-notification-cleaner.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.junk-notification-cleaner.gschema.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
+  <enum id="org.gnome.shell.extensions.junk-notification-cleaner.log-level">
+    <value nick="debug" value="0"/>
+    <value nick="info" value="1"/>
+    <value nick="warn" value="2"/>
+    <value nick="error" value="3"/>
+  </enum>
   <schema id="org.gnome.shell.extensions.junk-notification-cleaner" path="/org/gnome/shell/extensions/junk-notification-cleaner/">
     <key name="delete-on-focus" type="b">
       <default>true</default>
@@ -16,7 +22,7 @@
       <summary>Excluded applications</summary>
       <description>List of application ids (.desktop file names without the suffix) for which notifications should not be automatically deleted.</description>
     </key>
-    <key name="log-level" type="s">
+    <key name="log-level" enum="org.gnome.shell.extensions.junk-notification-cleaner.log-level">
       <default>'info'</default>
       <summary>Log level</summary>
       <description>Set the logging level for troubleshooting notification matching issues.</description>

--- a/schemas/org.gnome.shell.extensions.junk-notification-cleaner.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.junk-notification-cleaner.gschema.xml
@@ -14,7 +14,7 @@
     <key name="excluded-apps" type="as">
       <default>[]</default>
       <summary>Excluded applications</summary>
-      <description>List of application regex patterns for which notifications should not be automatically deleted.</description>
+      <description>List of application ids (.desktop file names without the suffix) for which notifications should not be automatically deleted.</description>
     </key>
     <key name="log-level" type="s">
       <default>'info'</default>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import type Gio from "gi://Gio";
 import type Meta from "gi://Meta";
+import type { Source } from "@girs/gnome-shell/ui/messageTray";
 
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
 import { Extension } from "resource:///org/gnome/shell/extensions/extension.js";
@@ -39,21 +40,68 @@ function getSourceLabel(source: { title: string; policy: unknown }) {
   });
 }
 
-// Fallback for generic-policy sources (libnotify clients that don't send a
-// desktop-entry hint, e.g. Slack channel messages): match by source.title
-// against the app's display name. Clients are free to set source.title to
-// anything, so this is a heuristic and may yield false positives for apps
-// whose notifications carry per-conversation titles.
+type MatchSource = Omit<Source, "icon"> & { icon: Source["icon"] | null };
+type MatchWindow = Omit<Meta.Window, "title"> & { title: string | null };
+
+function matchByPolicyId(source: MatchSource, appId: string) {
+  return (
+    source.policy instanceof NotificationApplicationPolicy &&
+    source.policy.id === appId
+  );
+}
+
+// libnotify clients without a desktop-entry hint set source.icon to an
+// app-identifying string. Compare it against window-side identifiers.
+function matchByIcon(source: MatchSource, window: MatchWindow) {
+  const icon = source.icon?.to_string();
+  if (!icon) return false;
+  return (
+    // Ghostty deb: icon matches GTK app id (com.mitchellh.ghostty)
+    icon === window.gtkApplicationId ||
+    // Slack Flatpak: icon matches sandboxed app id (com.slack.Slack)
+    icon === window.get_sandboxed_app_id() ||
+    // Firefox deb: icon matches window manager class (firefox)
+    icon === window.wmClass
+  );
+}
+
+// Snap apps have icon paths like /snap/firefox/6638/default256.png; their
+// sandboxed ids use format appname_appname (firefox_firefox).
+function matchBySnapIcon(source: MatchSource, window: MatchWindow) {
+  const regex = /^\/snap\/([^/]+)\//;
+  const snap = source.icon?.to_string()?.match(regex)?.at(1);
+  if (!snap) return false;
+  return window.get_sandboxed_app_id() === `${snap}_${snap}`;
+}
+
+function matchByTitle({ title }: MatchSource, window: MatchWindow) {
+  if (!title) return false;
+  return (
+    // Proton Mail Bridge: title matches window title
+    title === window.title ||
+    // Extract app name from composite title (foo.ts - project - Cursor)
+    title === window.title?.match(/^.+ (-|\|) (.+)$/)?.[2] ||
+    // Thunderbird: title matches window manager class (thunderbird)
+    title === window.wmClass ||
+    // Discord snap: title duplicated matches sandboxed app id (discord_discord)
+    `${title}_${title}` === window.get_sandboxed_app_id()
+  );
+}
+
+// Sources backed by NotificationApplicationPolicy carry the desktop-entry id;
+// otherwise fall back to empirical icon/title heuristics against the focused
+// window (covers libnotify clients without a desktop-entry hint).
 function sourceMatchesApp(
-  source: { title: string; policy: unknown },
+  source: MatchSource,
+  window: MatchWindow,
   appId: string,
-  appName: string,
 ) {
-  if (source.policy instanceof NotificationApplicationPolicy) {
-    return source.policy.id === appId;
-  } else {
-    return Boolean(appName) && source.title === appName;
-  }
+  return (
+    matchByPolicyId(source, appId) ||
+    matchByIcon(source, window) ||
+    matchBySnapIcon(source, window) ||
+    matchByTitle(source, window)
+  );
 }
 
 export default class JunkNotificationCleaner extends Extension {
@@ -101,7 +149,6 @@ export default class JunkNotificationCleaner extends Extension {
       return;
     }
 
-    const appName = app.get_name();
     for (const source of Main.messageTray.getSources()) {
       const sourceLabel = getSourceLabel(source);
       for (const notification of [...source.notifications]) {
@@ -113,7 +160,7 @@ export default class JunkNotificationCleaner extends Extension {
           `${label}: found ${kind} notification: ${title}`,
         );
         if (notification.isTransient) continue;
-        if (sourceMatchesApp(source, appId, appName)) {
+        if (sourceMatchesApp(source, window, appId)) {
           notification.destroy();
           this.log(LogLevel.INFO, `${label}: removed notification: ${title}`);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,21 +18,25 @@ export enum LogLevel {
 
 function getObjectLabel(name: string, values: Record<string, string | null>) {
   const labels = Object.entries(values)
-    .filter((entry): entry is [string, string] => entry[1] != null)
+    .filter((entry): entry is [string, string] => !!entry[1])
     .map(([label, value]) => `${label}: '${value}'`);
   return `${name}(${labels.join(", ")})`;
 }
 
-function getWindowLabel(window: Meta.Window, app?: Shell.App | null) {
+function getWindowLabel(window: MatchWindow, app?: Shell.App | null) {
   return getObjectLabel("Window", {
     Title: window.title,
     AppId: app?.id ?? null,
+    GtkAppId: window.gtkApplicationId,
+    WmClass: window.wmClass,
+    SandboxedAppId: window.get_sandboxed_app_id(),
   });
 }
 
-function getSourceLabel(source: { title: string; policy: unknown }) {
+function getSourceLabel(source: MatchSource) {
   return getObjectLabel("Source", {
     Title: source.title,
+    Icon: source.icon?.to_string() ?? null,
     PolicyId:
       source.policy instanceof NotificationApplicationPolicy
         ? source.policy.id
@@ -40,8 +44,15 @@ function getSourceLabel(source: { title: string; policy: unknown }) {
   });
 }
 
-type MatchSource = Omit<Source, "icon"> & { icon: Source["icon"] | null };
-type MatchWindow = Omit<Meta.Window, "title"> & { title: string | null };
+type MatchSource = Pick<Source, "title" | "policy"> & {
+  icon: Source["icon"] | null;
+};
+type MatchWindow = Pick<
+  Meta.Window,
+  "wmClass" | "gtkApplicationId" | "get_sandboxed_app_id"
+> & {
+  title: string | null;
+};
 
 // libnotify clients without a desktop-entry hint set source.icon to an
 // app-identifying string. Compare it against window-side identifiers.
@@ -65,11 +76,14 @@ function matchBySnapIcon(icon: string, window: MatchWindow) {
 }
 
 function matchByTitle(title: string, window: MatchWindow) {
+  if (window.title == null) return false;
   return (
     // Proton Mail Bridge: title matches window title
     title === window.title ||
-    // Extract app name from composite title (foo.ts - project - Cursor)
-    title === window.title?.match(/^.+ (-|\|) (.+)$/)?.[2] ||
+    // Extract app name from composite title separated by " - " or " | ".
+    // `^.+` is greedy, so the rightmost separator wins:
+    // "foo.ts - project - Cursor" -> "Cursor", "doc | App" -> "App".
+    title === /^.+ (-|\|) (.+)$/.exec(window.title)?.[2] ||
     // Thunderbird: title matches window manager class (thunderbird)
     title === window.wmClass ||
     // Discord snap: title duplicated matches sandboxed app id (discord_discord)
@@ -101,11 +115,10 @@ export default class JunkNotificationCleaner extends Extension {
   private windowTracker = Shell.WindowTracker.get_default();
 
   private log(level: LogLevel, message: string) {
-    let minLevel = this.settings?.get_string("log-level") as LogLevel | null;
-    minLevel ??= LogLevel.INFO;
-    const levels = Object.values(LogLevel);
-    if (!levels.includes(minLevel)) minLevel = LogLevel.INFO;
-    if (levels.indexOf(level) >= levels.indexOf(minLevel)) {
+    // gschema enum maps debug=0, info=1, warn=2, error=3, matching the
+    // declaration order of LogLevel; compare ints directly.
+    const minLevelIdx = this.settings?.get_enum("log-level") ?? 1;
+    if (Object.values(LogLevel).indexOf(level) >= minLevelIdx) {
       log(`[${this.metadata.uuid}][${level}] ${message}`);
     }
   }
@@ -141,9 +154,9 @@ export default class JunkNotificationCleaner extends Extension {
     }
 
     for (const source of Main.messageTray.getSources()) {
-      const sourceLabel = getSourceLabel(source);
+      const label = `${windowLabel}: ${getSourceLabel(source)}`;
+      const matches = sourceMatchesApp(source, window, appId);
       for (const notification of [...source.notifications]) {
-        const label = `${windowLabel}: ${sourceLabel}`;
         const title = notification.title ?? "(untitled notification)";
         const kind = notification.isTransient ? "transient" : "persistent";
         this.log(
@@ -151,7 +164,7 @@ export default class JunkNotificationCleaner extends Extension {
           `${label}: found ${kind} notification: ${title}`,
         );
         if (notification.isTransient) continue;
-        if (sourceMatchesApp(source, window, appId)) {
+        if (matches) {
           notification.destroy();
           this.log(LogLevel.INFO, `${label}: removed notification: ${title}`);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,6 @@ function getObjectLabel(name: string, values: Record<string, string | null>) {
 function getWindowLabel(window: Meta.Window, app?: Shell.App | null) {
   return getObjectLabel("Window", {
     Title: window.title,
-    WMClass: window.wmClass,
     AppId: app?.id ?? null,
   });
 }
@@ -75,24 +74,15 @@ export default class JunkNotificationCleaner extends Extension {
       return;
     }
 
-    const excludedApps = settings.get_strv("excluded-apps");
-    for (const pattern of excludedApps) {
-      let regex: RegExp;
-      try {
-        regex = new RegExp(pattern);
-      } catch {
-        this.log(LogLevel.WARN, `${windowLabel}: invalid regex '${pattern}'`);
-        continue;
-      }
-      if (window.wmClass !== null && regex.test(window.wmClass)) {
-        this.log(LogLevel.DEBUG, `${windowLabel}: excluded by '${pattern}'`);
-        return;
-      }
-    }
-
     // WindowTracker returns the desktop file id (e.g. "com.foo.desktop"),
     // but NotificationApplicationPolicy.id strips the ".desktop" suffix.
     const appId = app.id.replace(/\.desktop$/, "");
+
+    const excludedApps = settings.get_strv("excluded-apps");
+    if (excludedApps.includes(appId)) {
+      this.log(LogLevel.DEBUG, `${windowLabel}: excluded by app id '${appId}'`);
+      return;
+    }
 
     const appName = app.get_name();
     for (const source of Main.messageTray.getSources()) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,18 +43,9 @@ function getSourceLabel(source: { title: string; policy: unknown }) {
 type MatchSource = Omit<Source, "icon"> & { icon: Source["icon"] | null };
 type MatchWindow = Omit<Meta.Window, "title"> & { title: string | null };
 
-function matchByPolicyId(source: MatchSource, appId: string) {
-  return (
-    source.policy instanceof NotificationApplicationPolicy &&
-    source.policy.id === appId
-  );
-}
-
 // libnotify clients without a desktop-entry hint set source.icon to an
 // app-identifying string. Compare it against window-side identifiers.
-function matchByIcon(source: MatchSource, window: MatchWindow) {
-  const icon = source.icon?.to_string();
-  if (!icon) return false;
+function matchByIcon(icon: string, window: MatchWindow) {
   return (
     // Ghostty deb: icon matches GTK app id (com.mitchellh.ghostty)
     icon === window.gtkApplicationId ||
@@ -65,17 +56,15 @@ function matchByIcon(source: MatchSource, window: MatchWindow) {
   );
 }
 
-// Snap apps have icon paths like /snap/firefox/6638/default256.png; their
-// sandboxed ids use format appname_appname (firefox_firefox).
-function matchBySnapIcon(source: MatchSource, window: MatchWindow) {
-  const regex = /^\/snap\/([^/]+)\//;
-  const snap = source.icon?.to_string()?.match(regex)?.at(1);
+// Snap apps expose icon paths like /snap/firefox/6638/default256.png; their
+// sandboxed ids often duplicate the snap name (firefox_firefox).
+function matchBySnapIcon(icon: string, window: MatchWindow) {
+  const snap = /^\/snap\/([^/]+)\//.exec(icon)?.[1];
   if (!snap) return false;
   return window.get_sandboxed_app_id() === `${snap}_${snap}`;
 }
 
-function matchByTitle({ title }: MatchSource, window: MatchWindow) {
-  if (!title) return false;
+function matchByTitle(title: string, window: MatchWindow) {
   return (
     // Proton Mail Bridge: title matches window title
     title === window.title ||
@@ -88,20 +77,21 @@ function matchByTitle({ title }: MatchSource, window: MatchWindow) {
   );
 }
 
-// Sources backed by NotificationApplicationPolicy carry the desktop-entry id;
-// otherwise fall back to empirical icon/title heuristics against the focused
-// window (covers libnotify clients without a desktop-entry hint).
+// Prefer authoritative identifiers (policy id, source icon) when present.
+// If an icon is set, do not fall back to title matching; title is a
+// last-ditch heuristic reserved for sources that expose neither.
 function sourceMatchesApp(
   source: MatchSource,
   window: MatchWindow,
   appId: string,
 ) {
-  return (
-    matchByPolicyId(source, appId) ||
-    matchByIcon(source, window) ||
-    matchBySnapIcon(source, window) ||
-    matchByTitle(source, window)
-  );
+  if (source.policy instanceof NotificationApplicationPolicy) {
+    return source.policy.id === appId;
+  }
+  const icon = source.icon?.to_string();
+  if (icon) return matchByIcon(icon, window) || matchBySnapIcon(icon, window);
+  if (source.title) return matchByTitle(source.title, window);
+  return false;
 }
 
 export default class JunkNotificationCleaner extends Extension {
@@ -139,8 +129,9 @@ export default class JunkNotificationCleaner extends Extension {
       return;
     }
 
-    // WindowTracker returns the desktop file id (e.g. "com.foo.desktop"),
-    // but NotificationApplicationPolicy.id strips the ".desktop" suffix.
+    // Shell.App.id is the desktop filename (e.g. "org.gnome.Nautilus.desktop");
+    // NotificationApplicationPolicy.id stores the same id without the
+    // ".desktop" suffix, so normalize before comparison.
     const appId = app.id.replace(/\.desktop$/, "");
 
     const excludedApps = settings.get_strv("excluded-apps");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,9 +97,10 @@ export default class JunkNotificationCleaner extends Extension {
         );
         if (notification.isTransient) continue;
         // Fallback for generic-policy sources (libnotify clients that don't
-        // send a desktop-entry hint, e.g. Slack channel messages): both
-        // source.title and app.get_name() resolve to the .desktop file's Name=
-        // field, so equality is an identity check, not a heuristic.
+        // send a desktop-entry hint, e.g. Slack channel messages): match by
+        // source.title against the app's display name. Clients are free to set
+        // source.title to anything, so this is a heuristic and may yield false
+        // positives for apps whose notifications carry per-conversation titles.
         const matches =
           source.policy instanceof NotificationApplicationPolicy
             ? source.policy.id === appId

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,23 @@ function getSourceLabel(source: { title: string; policy: unknown }) {
   });
 }
 
+// Fallback for generic-policy sources (libnotify clients that don't send a
+// desktop-entry hint, e.g. Slack channel messages): match by source.title
+// against the app's display name. Clients are free to set source.title to
+// anything, so this is a heuristic and may yield false positives for apps
+// whose notifications carry per-conversation titles.
+function sourceMatchesApp(
+  source: { title: string; policy: unknown },
+  appId: string,
+  appName: string,
+) {
+  if (source.policy instanceof NotificationApplicationPolicy) {
+    return source.policy.id === appId;
+  } else {
+    return Boolean(appName) && source.title === appName;
+  }
+}
+
 export default class JunkNotificationCleaner extends Extension {
   private focusListenerId: number | null = null;
   private closeListenerId: number | null = null;
@@ -88,26 +105,17 @@ export default class JunkNotificationCleaner extends Extension {
     for (const source of Main.messageTray.getSources()) {
       const sourceLabel = getSourceLabel(source);
       for (const notification of [...source.notifications]) {
-        const prefix = `${windowLabel}: ${sourceLabel}`;
-        const suffix = notification.title ? `: ${notification.title}` : "";
+        const label = `${windowLabel}: ${sourceLabel}`;
+        const title = notification.title ?? "(untitled notification)";
         const kind = notification.isTransient ? "transient" : "persistent";
         this.log(
           LogLevel.DEBUG,
-          `${prefix}: found ${kind} notification${suffix}`,
+          `${label}: found ${kind} notification: ${title}`,
         );
         if (notification.isTransient) continue;
-        // Fallback for generic-policy sources (libnotify clients that don't
-        // send a desktop-entry hint, e.g. Slack channel messages): match by
-        // source.title against the app's display name. Clients are free to set
-        // source.title to anything, so this is a heuristic and may yield false
-        // positives for apps whose notifications carry per-conversation titles.
-        const matches =
-          source.policy instanceof NotificationApplicationPolicy
-            ? source.policy.id === appId
-            : Boolean(appName) && source.title === appName;
-        if (matches) {
+        if (sourceMatchesApp(source, appId, appName)) {
           notification.destroy();
-          this.log(LogLevel.INFO, `${prefix}: removed notification${suffix}`);
+          this.log(LogLevel.INFO, `${label}: removed notification: ${title}`);
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,6 +94,7 @@ export default class JunkNotificationCleaner extends Extension {
     // but NotificationApplicationPolicy.id strips the ".desktop" suffix.
     const appId = app.id.replace(/\.desktop$/, "");
 
+    const appName = app.get_name();
     for (const source of Main.messageTray.getSources()) {
       const sourceLabel = getSourceLabel(source);
       for (const notification of [...source.notifications]) {
@@ -105,12 +106,15 @@ export default class JunkNotificationCleaner extends Extension {
           `${prefix}: found ${kind} notification${suffix}`,
         );
         if (notification.isTransient) continue;
-        // Only sources tied to a desktop app expose an app id; system sources
-        // (NotificationGenericPolicy) intentionally don't match any window.
-        if (
-          source.policy instanceof NotificationApplicationPolicy &&
-          source.policy.id === appId
-        ) {
+        // Fallback for generic-policy sources (libnotify clients that don't
+        // send a desktop-entry hint, e.g. Slack channel messages): both
+        // source.title and app.get_name() resolve to the .desktop file's Name=
+        // field, so equality is an identity check, not a heuristic.
+        const matches =
+          source.policy instanceof NotificationApplicationPolicy
+            ? source.policy.id === appId
+            : Boolean(appName) && source.title === appName;
+        if (matches) {
           notification.destroy();
           this.log(LogLevel.INFO, `${prefix}: removed notification${suffix}`);
         }

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -165,10 +165,9 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
   }
 
   private buildExcludedAppRow(appId: string): Adw.ActionRow {
-    const row = buildAppRow(
-      GioUnix.DesktopAppInfo.new(`${appId}.desktop`),
-      appId,
-    );
+    const app = tryLoadDesktopApp(appId);
+    const row = buildAppRow(app, appId);
+    if (!app) row.set_subtitle("Uninstalled");
 
     const removeButton = new Gtk.Button({
       icon_name: "user-trash-symbolic",
@@ -252,6 +251,12 @@ function buildSelectableAppList(
   }
 
   return appList;
+}
+
+// DesktopAppInfo.new is typed as non-null but returns null when the
+// .desktop file is missing (e.g. the user uninstalled the app).
+function tryLoadDesktopApp(appId: string): GioUnix.DesktopAppInfo | null {
+  return GioUnix.DesktopAppInfo.new(`${appId}.desktop`);
 }
 
 function buildAppRow(

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -223,7 +223,9 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
   private getSelectableApps(): Gio.AppInfo[] {
     const excluded = new Set(this.model.getExcludedApps());
     return Gio.AppInfo.get_all()
-      .filter((a) => a.should_show() && !excluded.has(getAppId(a)))
+      .filter(
+        (a) => a.should_show() && a.get_id() && !excluded.has(getAppId(a)),
+      )
       .sort((a, b) => a.get_name().localeCompare(b.get_name()));
   }
 }
@@ -337,15 +339,11 @@ class PreferencesModel {
   }
 
   getLogLevelIndex(): number {
-    const current = this.settings.get_string("log-level") as `${LogLevel}`;
-    const idx = LOG_LEVELS.indexOf(current);
-    if (idx >= 0) return idx;
-    logError(`Invalid log level in settings: ${current}, setting to "info".`);
-    return LOG_LEVELS.indexOf("info");
+    return this.settings.get_enum("log-level");
   }
 
   setLogLevelIndex(idx: number): void {
-    this.settings.set_string("log-level", LOG_LEVELS[idx] ?? "info");
+    this.settings.set_enum("log-level", idx);
   }
 
   onLogLevelChanged(handler: () => void): number {

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -9,14 +9,14 @@ import type { LogLevel } from "./extension.js";
 
 type DeleteTriggerKey = "delete-on-focus" | "delete-on-close";
 
-class PreferencesModel {
-  static readonly LOG_LEVELS = [
-    "debug",
-    "info",
-    "warn",
-    "error",
-  ] as const satisfies `${LogLevel}`[];
+const LOG_LEVELS = [
+  "debug",
+  "info",
+  "warn",
+  "error",
+] as const satisfies `${LogLevel}`[];
 
+class PreferencesModel {
   constructor(private settings: Gio.Settings) {}
 
   bindDeleteTrigger(
@@ -50,17 +50,14 @@ class PreferencesModel {
 
   getLogLevelIndex(): number {
     const current = this.settings.get_string("log-level") as `${LogLevel}`;
-    const idx = PreferencesModel.LOG_LEVELS.indexOf(current);
+    const idx = LOG_LEVELS.indexOf(current);
     if (idx >= 0) return idx;
     logError(`Invalid log level in settings: ${current}, setting to "info".`);
-    return PreferencesModel.LOG_LEVELS.indexOf("info");
+    return LOG_LEVELS.indexOf("info");
   }
 
   setLogLevelIndex(idx: number): void {
-    this.settings.set_string(
-      "log-level",
-      PreferencesModel.LOG_LEVELS[idx] ?? "info",
-    );
+    this.settings.set_string("log-level", LOG_LEVELS[idx] ?? "info");
   }
 
   onLogLevelChanged(handler: () => void): number {
@@ -69,18 +66,6 @@ class PreferencesModel {
 
   disconnect(handlerId: number): void {
     this.settings.disconnect(handlerId);
-  }
-
-  getSelectableApps(): Gio.AppInfo[] {
-    const excluded = new Set(this.getExcludedApps());
-    return Gio.AppInfo.get_all()
-      .filter((a) => {
-        const id = getAppId(a);
-        return a.should_show() && id !== "" && !excluded.has(id);
-      })
-      .sort((a, b) => {
-        return a.get_name().localeCompare(b.get_name());
-      });
   }
 }
 
@@ -95,8 +80,69 @@ function lookupApp(appId: string): GioUnix.DesktopAppInfo | null {
 function rowMatchesQuery(row: Adw.ActionRow, query: string): boolean {
   if (query === "") return true;
   const title = row.get_title().toLowerCase();
-  const subtitle = (row.get_subtitle() ?? "").toLowerCase();
+  const subtitle = row.get_subtitle()?.toLowerCase() ?? "";
   return title.includes(query) || subtitle.includes(query);
+}
+
+function buildSearchHeader(): {
+  headerBar: Adw.HeaderBar;
+  search: Gtk.SearchEntry;
+} {
+  const search = new Gtk.SearchEntry({
+    placeholder_text: "Search applications",
+    hexpand: true,
+  });
+  const headerBar = new Adw.HeaderBar();
+  headerBar.set_title_widget(search);
+  return { headerBar, search };
+}
+
+function wireSearchFilter(appList: Gtk.ListBox, search: Gtk.SearchEntry): void {
+  appList.set_filter_func((row) =>
+    rowMatchesQuery(
+      row as Adw.ActionRow,
+      search.get_text().toLowerCase().trim(),
+    ),
+  );
+  search.connect("search-changed", () => {
+    appList.invalidate_filter();
+  });
+}
+
+function addCloseOnEscape(window: Gtk.Window): void {
+  const controller = new Gtk.ShortcutController();
+  controller.add_shortcut(
+    new Gtk.Shortcut({
+      trigger: Gtk.ShortcutTrigger.parse_string("Escape"),
+      action: Gtk.ShortcutAction.parse_string("action(window.close)"),
+    }),
+  );
+  window.add_controller(controller);
+}
+
+function buildSelectableAppList(
+  apps: Gio.AppInfo[],
+  onActivated: (appId: string) => void,
+): Gtk.ListBox {
+  const appList = new Gtk.ListBox({
+    selection_mode: Gtk.SelectionMode.NONE,
+    css_classes: ["boxed-list"],
+    margin_top: 8,
+    margin_bottom: 8,
+    margin_start: 8,
+    margin_end: 8,
+  });
+
+  for (const app of apps) {
+    const appId = getAppId(app);
+    const row = buildAppRow(app, appId, { activatable: true });
+    appList.append(row);
+    row.connect("activated", () => {
+      onActivated(appId);
+    });
+  }
+
+  return appList;
 }
 
 function buildAppRow(
@@ -179,25 +225,36 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
         "Set the logging level for troubleshooting notification matching.",
     });
     const dropdown = new Gtk.DropDown({
-      model: Gtk.StringList.new([...PreferencesModel.LOG_LEVELS]),
+      model: Gtk.StringList.new([...LOG_LEVELS]),
       valign: Gtk.Align.CENTER,
     });
 
-    const syncDropdown = () => {
+    this.bindLogLevelDropdown(dropdown);
+
+    row.add_suffix(dropdown);
+    group.add(row);
+    return group;
+  }
+
+  private getSelectableApps(): Gio.AppInfo[] {
+    const excluded = new Set(this.model.getExcludedApps());
+    return Gio.AppInfo.get_all()
+      .filter((a) => a.should_show() && !excluded.has(getAppId(a)))
+      .sort((a, b) => a.get_name().localeCompare(b.get_name()));
+  }
+
+  private bindLogLevelDropdown(dropdown: Gtk.DropDown): void {
+    const sync = () => {
       dropdown.set_selected(this.model.getLogLevelIndex());
     };
-    syncDropdown();
-    const changedId = this.model.onLogLevelChanged(syncDropdown);
+    sync();
+    const changedId = this.model.onLogLevelChanged(sync);
     dropdown.connect("notify::selected", (dd: Gtk.DropDown) => {
       this.model.setLogLevelIndex(dd.get_selected());
     });
     dropdown.connect("destroy", () => {
       this.model.disconnect(changedId);
     });
-
-    row.add_suffix(dropdown);
-    group.add(row);
-    return group;
   }
 
   private buildExcludedAppsGroup(): Adw.PreferencesGroup {
@@ -276,28 +333,6 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
     return row;
   }
 
-  private buildSelectableAppList(
-    onActivated: (appId: string) => unknown,
-  ): Gtk.ListBox {
-    const appList = new Gtk.ListBox({
-      selection_mode: Gtk.SelectionMode.NONE,
-      css_classes: ["boxed-list"],
-      margin_top: 8,
-      margin_bottom: 8,
-      margin_start: 8,
-      margin_end: 8,
-    });
-
-    for (const app of this.model.getSelectableApps()) {
-      const appId = getAppId(app);
-      const row = buildAppRow(app, appId, { activatable: true });
-      row.connect("activated", () => onActivated(appId));
-      appList.append(row);
-    }
-
-    return appList;
-  }
-
   private openAppSelector(
     parent: Gtk.Window | null,
     onSelected: (appId: string) => void,
@@ -310,36 +345,14 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
     });
     if (parent) window.set_transient_for(parent);
 
-    const search = new Gtk.SearchEntry({
-      placeholder_text: "Search applications",
-      hexpand: true,
-    });
-    const headerBar = new Adw.HeaderBar();
-    headerBar.set_title_widget(search);
+    const { headerBar, search } = buildSearchHeader();
 
-    const appList = this.buildSelectableAppList((appId) => {
+    const appList = buildSelectableAppList(this.getSelectableApps(), (appId) => {
       onSelected(appId);
       window.close();
     });
-
-    appList.set_filter_func((row) =>
-      rowMatchesQuery(
-        row as Adw.ActionRow,
-        search.get_text().toLowerCase().trim(),
-      ),
-    );
-    search.connect("search-changed", () => {
-      appList.invalidate_filter();
-    });
-
-    const escController = new Gtk.ShortcutController();
-    escController.add_shortcut(
-      new Gtk.Shortcut({
-        trigger: Gtk.ShortcutTrigger.parse_string("Escape"),
-        action: Gtk.ShortcutAction.parse_string("action(window.close)"),
-      }),
-    );
-    window.add_controller(escController);
+    wireSearchFilter(appList, search);
+    addCloseOnEscape(window);
 
     const toolbarView = new Adw.ToolbarView();
     toolbarView.add_top_bar(headerBar);

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -1,18 +1,18 @@
 import Adw from "gi://Adw";
 import Gio from "gi://Gio";
+import GioUnix from "gi://GioUnix";
 import Gtk from "gi://Gtk";
 import { ExtensionPreferences } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 import type { LogLevel } from "./extension.js";
 
 const LOG_LEVELS: LogLevel[] = ["debug", "info", "warn", "error"] as LogLevel[];
 
-function isValidRegex(pattern: string): boolean {
-  try {
-    new RegExp(pattern);
-    return true;
-  } catch {
-    return false;
-  }
+function getAppId(app: GioUnix.DesktopAppInfo): string {
+  return (app.get_id() ?? "").replace(/\.desktop$/, "");
+}
+
+function lookupApp(appId: string): GioUnix.DesktopAppInfo | null {
+  return GioUnix.DesktopAppInfo.new(`${appId}.desktop`);
 }
 
 export default class JunkNotificationCleanerPreferences extends ExtensionPreferences {
@@ -90,127 +90,167 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
     debugGroup.add(logLevelRow);
 
     const excludedGroup = new Adw.PreferencesGroup();
-    excludedGroup.set_title("Excluded WM Classes");
+    excludedGroup.set_title("Excluded Applications");
     excludedGroup.set_description(
-      [
-        "Window Manager Classes whose notifications will not be automatically deleted.",
-        "Will be matched against the wm_class property of the window, supports ECMAScript regular expressions.",
-      ].join("\n"),
+      "Applications whose notifications will not be automatically deleted.",
     );
-    page.add(excludedGroup);
 
-    const excludedBox = new Gtk.Box({
-      orientation: Gtk.Orientation.VERTICAL,
-      margin_top: 8,
-      margin_bottom: 8,
-      margin_start: 8,
-      margin_end: 8,
-      spacing: 8,
+    const addButton = new Gtk.Button({
+      icon_name: "list-add-symbolic",
+      tooltip_text: "Add application",
+      css_classes: ["flat"],
+      valign: Gtk.Align.CENTER,
     });
-
-    const excludedApps = settings.get_strv("excluded-apps");
+    excludedGroup.set_header_suffix(addButton);
+    page.add(excludedGroup);
 
     const listBox = new Gtk.ListBox({
       selection_mode: Gtk.SelectionMode.NONE,
       css_classes: ["boxed-list"],
     });
-    excludedBox.append(listBox);
+    excludedGroup.add(listBox);
 
-    for (const app of excludedApps) {
-      this.addExcludedAppRow(app, listBox, settings);
+    const placeholder = new Gtk.Label({
+      label: "No excluded applications.",
+      css_classes: ["dim-label"],
+      margin_top: 12,
+      margin_bottom: 12,
+    });
+    listBox.set_placeholder(placeholder);
+
+    for (const appId of settings.get_strv("excluded-apps")) {
+      this.addExcludedAppRow(appId, listBox, settings);
     }
 
-    const addBox = new Gtk.Box({
-      orientation: Gtk.Orientation.HORIZONTAL,
-      spacing: 8,
-      margin_top: 8,
-    });
-
-    const entry = new Gtk.Entry({
-      placeholder_text: "Enter WM Class regex (e.g. .*firefox.*)",
-      hexpand: true,
-    });
-
-    const errorLabel = new Gtk.Label({
-      label: "Invalid regular expression",
-      css_classes: ["error"],
-      xalign: 0,
-      visible: false,
-    });
-
-    const addButton = new Gtk.Button({
-      label: "Add",
-      css_classes: ["suggested-action"],
-    });
-
-    entry.connect("changed", () => {
-      entry.remove_css_class("error");
-      errorLabel.set_visible(false);
-    });
-
     addButton.connect("clicked", () => {
-      const text = entry.get_text().trim();
-      if (!text) return;
-      if (!isValidRegex(text)) {
-        entry.add_css_class("error");
-        errorLabel.set_visible(true);
-      } else {
-        entry.remove_css_class("error");
-        errorLabel.set_visible(false);
-        const currentApps = settings.get_strv("excluded-apps");
-        if (currentApps.includes(text)) return;
-        settings.set_strv("excluded-apps", [...currentApps, text]);
-        this.addExcludedAppRow(text, listBox, settings);
-        entry.set_text("");
-      }
+      this.openAppSelector(
+        addButton.get_root() as Gtk.Window | null,
+        listBox,
+        settings,
+      );
     });
-
-    addBox.append(entry);
-    addBox.append(addButton);
-
-    excludedBox.append(addBox);
-    excludedBox.append(errorLabel);
-    excludedGroup.add(excludedBox);
 
     return page;
   }
 
-  addExcludedAppRow(
-    app: string,
+  openAppSelector(
+    parent: Gtk.Window | null,
     listBox: Gtk.ListBox,
     settings: Gio.Settings,
   ): void {
-    const row = new Gtk.ListBoxRow();
-    const box = new Gtk.Box({
-      orientation: Gtk.Orientation.HORIZONTAL,
-      spacing: 8,
+    const excluded = new Set(settings.get_strv("excluded-apps"));
+    const apps = (Gio.AppInfo.get_all() as GioUnix.DesktopAppInfo[])
+      .filter((a) => {
+        const id = getAppId(a);
+        return a.should_show() && id !== "" && !excluded.has(id);
+      })
+      .sort((a, b) => {
+        return a.get_name().localeCompare(b.get_name());
+      });
+
+    const window = new Adw.Window({
+      title: "Add Excluded Application",
+      modal: true,
+      default_width: 420,
+      default_height: 520,
+    });
+    if (parent) window.set_transient_for(parent);
+
+    const search = new Gtk.SearchEntry({
+      placeholder_text: "Search applications",
+      hexpand: true,
+    });
+
+    const headerBar = new Adw.HeaderBar();
+    headerBar.set_title_widget(search);
+
+    const appList = new Gtk.ListBox({
+      selection_mode: Gtk.SelectionMode.NONE,
+      css_classes: ["boxed-list"],
       margin_top: 8,
       margin_bottom: 8,
       margin_start: 8,
       margin_end: 8,
     });
 
-    const label = new Gtk.Label({
-      label: app,
-      hexpand: true,
-      xalign: 0,
+    let query = "";
+    appList.set_filter_func((row) => {
+      if (query === "") return true;
+      const actionRow = row as Adw.ActionRow;
+      const title = actionRow.get_title().toLowerCase();
+      const subtitle = (actionRow.get_subtitle() ?? "").toLowerCase();
+      return title.includes(query) || subtitle.includes(query);
     });
+
+    search.connect("search-changed", () => {
+      query = search.get_text().toLowerCase().trim();
+      appList.invalidate_filter();
+    });
+
+    for (const app of apps) {
+      const appId = getAppId(app);
+      const row = new Adw.ActionRow({
+        title: app.get_name(),
+        subtitle: appId,
+        activatable: true,
+      });
+      const icon = app.get_icon();
+      if (icon) {
+        const image = Gtk.Image.new_from_gicon(icon);
+        image.set_pixel_size(32);
+        row.add_prefix(image);
+      }
+      row.connect("activated", () => {
+        const current = settings.get_strv("excluded-apps");
+        if (!current.includes(appId)) {
+          settings.set_strv("excluded-apps", [...current, appId]);
+          this.addExcludedAppRow(appId, listBox, settings);
+        }
+        window.close();
+      });
+      appList.append(row);
+    }
+
+    const toolbarView = new Adw.ToolbarView();
+    toolbarView.add_top_bar(headerBar);
+    toolbarView.set_content(new Gtk.ScrolledWindow({ child: appList }));
+    window.set_content(toolbarView);
+    window.present();
+  }
+
+  addExcludedAppRow(
+    appId: string,
+    listBox: Gtk.ListBox,
+    settings: Gio.Settings,
+  ): void {
+    const app = lookupApp(appId);
+    const row = new Adw.ActionRow({
+      title: app?.get_name() ?? appId,
+      subtitle: appId,
+    });
+    const icon = app?.get_icon();
+    if (icon) {
+      const image = Gtk.Image.new_from_gicon(icon);
+      image.set_pixel_size(32);
+      row.add_prefix(image);
+    }
 
     const removeButton = new Gtk.Button({
       icon_name: "user-trash-symbolic",
       tooltip_text: "Remove",
+      css_classes: ["flat"],
+      valign: Gtk.Align.CENTER,
     });
-
     removeButton.connect("clicked", () => {
-      const currentApps = settings.get_strv("excluded-apps");
-      const newApps = currentApps.filter((a) => a !== app);
-      settings.set_strv("excluded-apps", newApps);
+      const current = settings.get_strv("excluded-apps");
+      settings.set_strv(
+        "excluded-apps",
+        current.filter((id) => id !== appId),
+      );
       listBox.remove(row);
     });
+    row.add_suffix(removeButton);
 
-    box.append(label);
-    box.append(removeButton);
-    row.set_child(box);
     listBox.append(row);
   }
 }

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -16,151 +16,6 @@ const LOG_LEVELS = [
   "error",
 ] as const satisfies `${LogLevel}`[];
 
-class PreferencesModel {
-  constructor(private settings: Gio.Settings) {}
-
-  bindDeleteTrigger(
-    key: DeleteTriggerKey,
-    target: GObject.Object,
-    property: string,
-  ): void {
-    this.settings.bind(key, target, property, Gio.SettingsBindFlags.DEFAULT);
-  }
-
-  getExcludedApps(): string[] {
-    return this.settings.get_strv("excluded-apps");
-  }
-
-  addExcludedApp(appId: string): void {
-    const current = this.getExcludedApps();
-    if (current.includes(appId)) return;
-    this.settings.set_strv("excluded-apps", [...current, appId]);
-  }
-
-  removeExcludedApp(appId: string): void {
-    this.settings.set_strv(
-      "excluded-apps",
-      this.getExcludedApps().filter((id) => id !== appId),
-    );
-  }
-
-  onExcludedAppsChanged(handler: () => void): number {
-    return this.settings.connect("changed::excluded-apps", handler);
-  }
-
-  getLogLevelIndex(): number {
-    const current = this.settings.get_string("log-level") as `${LogLevel}`;
-    const idx = LOG_LEVELS.indexOf(current);
-    if (idx >= 0) return idx;
-    logError(`Invalid log level in settings: ${current}, setting to "info".`);
-    return LOG_LEVELS.indexOf("info");
-  }
-
-  setLogLevelIndex(idx: number): void {
-    this.settings.set_string("log-level", LOG_LEVELS[idx] ?? "info");
-  }
-
-  onLogLevelChanged(handler: () => void): number {
-    return this.settings.connect("changed::log-level", handler);
-  }
-
-  disconnect(handlerId: number): void {
-    this.settings.disconnect(handlerId);
-  }
-}
-
-function getAppId(app: Gio.AppInfo): string {
-  return (app.get_id() ?? "").replace(/\.desktop$/, "");
-}
-
-function lookupApp(appId: string): GioUnix.DesktopAppInfo | null {
-  return GioUnix.DesktopAppInfo.new(`${appId}.desktop`);
-}
-
-function rowMatchesQuery(row: Adw.ActionRow, query: string): boolean {
-  if (query === "") return true;
-  const title = row.get_title().toLowerCase();
-  const subtitle = row.get_subtitle()?.toLowerCase() ?? "";
-  return title.includes(query) || subtitle.includes(query);
-}
-
-function buildSearchHeader(): {
-  headerBar: Adw.HeaderBar;
-  search: Gtk.SearchEntry;
-} {
-  const search = new Gtk.SearchEntry({
-    placeholder_text: "Search applications",
-    hexpand: true,
-  });
-  const headerBar = new Adw.HeaderBar();
-  headerBar.set_title_widget(search);
-  return { headerBar, search };
-}
-
-function wireSearchFilter(appList: Gtk.ListBox, search: Gtk.SearchEntry): void {
-  appList.set_filter_func((row) =>
-    rowMatchesQuery(
-      row as Adw.ActionRow,
-      search.get_text().toLowerCase().trim(),
-    ),
-  );
-  search.connect("search-changed", () => {
-    appList.invalidate_filter();
-  });
-}
-
-function addCloseOnEscape(window: Gtk.Window): void {
-  const controller = new Gtk.ShortcutController();
-  controller.add_shortcut(
-    new Gtk.Shortcut({
-      trigger: Gtk.ShortcutTrigger.parse_string("Escape"),
-      action: Gtk.ShortcutAction.parse_string("action(window.close)"),
-    }),
-  );
-  window.add_controller(controller);
-}
-
-function buildSelectableAppList(
-  apps: Gio.AppInfo[],
-  onActivated: (appId: string) => void,
-): Gtk.ListBox {
-  const appList = new Gtk.ListBox({
-    selection_mode: Gtk.SelectionMode.NONE,
-    css_classes: ["boxed-list"],
-    margin_top: 8,
-    margin_bottom: 8,
-    margin_start: 8,
-    margin_end: 8,
-  });
-
-  for (const app of apps) {
-    const appId = getAppId(app);
-    const row = buildAppRow(app, appId, { activatable: true });
-    appList.append(row);
-    row.connect("activated", () => {
-      onActivated(appId);
-    });
-  }
-
-  return appList;
-}
-
-function buildAppRow(
-  app: Gio.AppInfo | null,
-  appId: string,
-  extra: Partial<Adw.ActionRow.ConstructorProps> = {},
-): Adw.ActionRow {
-  const title = app?.get_name() ?? appId;
-  const row = new Adw.ActionRow({ ...extra, title, subtitle: appId });
-  const icon = app?.get_icon();
-  if (icon) {
-    const image = Gtk.Image.new_from_gicon(icon);
-    image.set_pixel_size(32);
-    row.add_prefix(image);
-  }
-  return row;
-}
-
 export default class JunkNotificationCleanerPreferences extends ExtensionPreferences {
   private model!: PreferencesModel;
 
@@ -234,13 +89,6 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
     row.add_suffix(dropdown);
     group.add(row);
     return group;
-  }
-
-  private getSelectableApps(): Gio.AppInfo[] {
-    const excluded = new Set(this.model.getExcludedApps());
-    return Gio.AppInfo.get_all()
-      .filter((a) => a.should_show() && !excluded.has(getAppId(a)))
-      .sort((a, b) => a.get_name().localeCompare(b.get_name()));
   }
 
   private bindLogLevelDropdown(dropdown: Gtk.DropDown): void {
@@ -317,7 +165,10 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
   }
 
   private buildExcludedAppRow(appId: string): Adw.ActionRow {
-    const row = buildAppRow(lookupApp(appId), appId);
+    const row = buildAppRow(
+      GioUnix.DesktopAppInfo.new(`${appId}.desktop`),
+      appId,
+    );
 
     const removeButton = new Gtk.Button({
       icon_name: "user-trash-symbolic",
@@ -345,12 +196,20 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
     });
     if (parent) window.set_transient_for(parent);
 
-    const { headerBar, search } = buildSearchHeader();
-
-    const appList = buildSelectableAppList(this.getSelectableApps(), (appId) => {
-      onSelected(appId);
-      window.close();
+    const search = new Gtk.SearchEntry({
+      placeholder_text: "Search applications",
+      hexpand: true,
     });
+    const headerBar = new Adw.HeaderBar();
+    headerBar.set_title_widget(search);
+
+    const appList = buildSelectableAppList(
+      this.getSelectableApps(),
+      (appId) => {
+        onSelected(appId);
+        window.close();
+      },
+    );
     wireSearchFilter(appList, search);
     addCloseOnEscape(window);
 
@@ -360,5 +219,135 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
     window.set_content(toolbarView);
     window.present();
     search.grab_focus();
+  }
+
+  private getSelectableApps(): Gio.AppInfo[] {
+    const excluded = new Set(this.model.getExcludedApps());
+    return Gio.AppInfo.get_all()
+      .filter((a) => a.should_show() && !excluded.has(getAppId(a)))
+      .sort((a, b) => a.get_name().localeCompare(b.get_name()));
+  }
+}
+
+function buildSelectableAppList(
+  apps: Gio.AppInfo[],
+  onActivated: (appId: string) => void,
+): Gtk.ListBox {
+  const appList = new Gtk.ListBox({
+    selection_mode: Gtk.SelectionMode.NONE,
+    css_classes: ["boxed-list"],
+    margin_top: 8,
+    margin_bottom: 8,
+    margin_start: 8,
+    margin_end: 8,
+  });
+
+  for (const app of apps) {
+    const appId = getAppId(app);
+    const row = buildAppRow(app, appId, { activatable: true });
+    appList.append(row);
+    row.connect("activated", () => {
+      onActivated(appId);
+    });
+  }
+
+  return appList;
+}
+
+function buildAppRow(
+  app: Gio.AppInfo | null,
+  appId: string,
+  extra: Partial<Adw.ActionRow.ConstructorProps> = {},
+): Adw.ActionRow {
+  const title = app?.get_name() ?? appId;
+  const row = new Adw.ActionRow({ ...extra, title, subtitle: appId });
+  const icon = app?.get_icon();
+  if (icon) {
+    const image = Gtk.Image.new_from_gicon(icon);
+    image.set_pixel_size(32);
+    row.add_prefix(image);
+  }
+  return row;
+}
+
+function wireSearchFilter(appList: Gtk.ListBox, search: Gtk.SearchEntry): void {
+  appList.set_filter_func((row) => {
+    const query = search.get_text().toLowerCase().trim();
+    if (query === "") return true;
+    const actionRow = row as Adw.ActionRow;
+    const title = actionRow.get_title().toLowerCase();
+    const subtitle = actionRow.get_subtitle()?.toLowerCase() ?? "";
+    return title.includes(query) || subtitle.includes(query);
+  });
+  search.connect("search-changed", () => {
+    appList.invalidate_filter();
+  });
+}
+
+function addCloseOnEscape(window: Gtk.Window): void {
+  const controller = new Gtk.ShortcutController();
+  controller.add_shortcut(
+    new Gtk.Shortcut({
+      trigger: Gtk.ShortcutTrigger.parse_string("Escape"),
+      action: Gtk.ShortcutAction.parse_string("action(window.close)"),
+    }),
+  );
+  window.add_controller(controller);
+}
+
+function getAppId(app: Gio.AppInfo): string {
+  return (app.get_id() ?? "").replace(/\.desktop$/, "");
+}
+
+class PreferencesModel {
+  constructor(private settings: Gio.Settings) {}
+
+  bindDeleteTrigger(
+    key: DeleteTriggerKey,
+    target: GObject.Object,
+    property: string,
+  ): void {
+    this.settings.bind(key, target, property, Gio.SettingsBindFlags.DEFAULT);
+  }
+
+  getExcludedApps(): string[] {
+    return this.settings.get_strv("excluded-apps");
+  }
+
+  addExcludedApp(appId: string): void {
+    const current = this.getExcludedApps();
+    if (current.includes(appId)) return;
+    this.settings.set_strv("excluded-apps", [...current, appId]);
+  }
+
+  removeExcludedApp(appId: string): void {
+    this.settings.set_strv(
+      "excluded-apps",
+      this.getExcludedApps().filter((id) => id !== appId),
+    );
+  }
+
+  onExcludedAppsChanged(handler: () => void): number {
+    return this.settings.connect("changed::excluded-apps", handler);
+  }
+
+  getLogLevelIndex(): number {
+    const current = this.settings.get_string("log-level") as `${LogLevel}`;
+    const idx = LOG_LEVELS.indexOf(current);
+    if (idx >= 0) return idx;
+    logError(`Invalid log level in settings: ${current}, setting to "info".`);
+    return LOG_LEVELS.indexOf("info");
+  }
+
+  setLogLevelIndex(idx: number): void {
+    this.settings.set_string("log-level", LOG_LEVELS[idx] ?? "info");
+  }
+
+  onLogLevelChanged(handler: () => void): number {
+    return this.settings.connect("changed::log-level", handler);
+  }
+
+  disconnect(handlerId: number): void {
+    this.settings.disconnect(handlerId);
   }
 }

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -3,11 +3,88 @@ import Gio from "gi://Gio";
 import GioUnix from "gi://GioUnix";
 import Gtk from "gi://Gtk";
 import { ExtensionPreferences } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
+
+import type GObject from "gi://GObject";
 import type { LogLevel } from "./extension.js";
 
-const LOG_LEVELS: `${LogLevel}`[] = ["debug", "info", "warn", "error"];
+type DeleteTriggerKey = "delete-on-focus" | "delete-on-close";
 
-function getAppId(app: GioUnix.DesktopAppInfo): string {
+class PreferencesModel {
+  static readonly LOG_LEVELS = [
+    "debug",
+    "info",
+    "warn",
+    "error",
+  ] as const satisfies `${LogLevel}`[];
+
+  constructor(private settings: Gio.Settings) {}
+
+  bindDeleteTrigger(
+    key: DeleteTriggerKey,
+    target: GObject.Object,
+    property: string,
+  ): void {
+    this.settings.bind(key, target, property, Gio.SettingsBindFlags.DEFAULT);
+  }
+
+  getExcludedApps(): string[] {
+    return this.settings.get_strv("excluded-apps");
+  }
+
+  addExcludedApp(appId: string): void {
+    const current = this.getExcludedApps();
+    if (current.includes(appId)) return;
+    this.settings.set_strv("excluded-apps", [...current, appId]);
+  }
+
+  removeExcludedApp(appId: string): void {
+    this.settings.set_strv(
+      "excluded-apps",
+      this.getExcludedApps().filter((id) => id !== appId),
+    );
+  }
+
+  onExcludedAppsChanged(handler: () => void): number {
+    return this.settings.connect("changed::excluded-apps", handler);
+  }
+
+  getLogLevelIndex(): number {
+    const current = this.settings.get_string("log-level") as `${LogLevel}`;
+    const idx = PreferencesModel.LOG_LEVELS.indexOf(current);
+    if (idx >= 0) return idx;
+    logError(`Invalid log level in settings: ${current}, setting to "info".`);
+    return PreferencesModel.LOG_LEVELS.indexOf("info");
+  }
+
+  setLogLevelIndex(idx: number): void {
+    this.settings.set_string(
+      "log-level",
+      PreferencesModel.LOG_LEVELS[idx] ?? "info",
+    );
+  }
+
+  onLogLevelChanged(handler: () => void): number {
+    return this.settings.connect("changed::log-level", handler);
+  }
+
+  disconnect(handlerId: number): void {
+    this.settings.disconnect(handlerId);
+  }
+
+  getSelectableApps(): Gio.AppInfo[] {
+    const excluded = new Set(this.getExcludedApps());
+    return Gio.AppInfo.get_all()
+      .filter((a) => {
+        const id = getAppId(a);
+        return a.should_show() && id !== "" && !excluded.has(id);
+      })
+      .sort((a, b) => {
+        return a.get_name().localeCompare(b.get_name());
+      });
+  }
+}
+
+function getAppId(app: Gio.AppInfo): string {
   return (app.get_id() ?? "").replace(/\.desktop$/, "");
 }
 
@@ -15,8 +92,15 @@ function lookupApp(appId: string): GioUnix.DesktopAppInfo | null {
   return GioUnix.DesktopAppInfo.new(`${appId}.desktop`);
 }
 
+function rowMatchesQuery(row: Adw.ActionRow, query: string): boolean {
+  if (query === "") return true;
+  const title = row.get_title().toLowerCase();
+  const subtitle = (row.get_subtitle() ?? "").toLowerCase();
+  return title.includes(query) || subtitle.includes(query);
+}
+
 function buildAppRow(
-  app: GioUnix.DesktopAppInfo | null | undefined,
+  app: Gio.AppInfo | null,
   appId: string,
   extra: Partial<Adw.ActionRow.ConstructorProps> = {},
 ): Adw.ActionRow {
@@ -32,10 +116,10 @@ function buildAppRow(
 }
 
 export default class JunkNotificationCleanerPreferences extends ExtensionPreferences {
-  private settings!: Gio.Settings;
+  private model!: PreferencesModel;
 
   getPreferencesWidget() {
-    this.settings = this.getSettings();
+    this.model = new PreferencesModel(this.getSettings());
 
     const page = new Adw.PreferencesPage();
     page.set_title("Settings");
@@ -47,40 +131,6 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
 
     return page;
   }
-
-  // ── business logic ──────────────────────────────────────────────────────
-
-  getExcludedApps(): string[] {
-    return this.settings.get_strv("excluded-apps");
-  }
-
-  addExcludedApp(appId: string): void {
-    const current = this.getExcludedApps();
-    if (current.includes(appId)) return;
-    this.settings.set_strv("excluded-apps", [...current, appId]);
-  }
-
-  removeExcludedApp(appId: string): void {
-    const current = this.getExcludedApps();
-    this.settings.set_strv(
-      "excluded-apps",
-      current.filter((id) => id !== appId),
-    );
-  }
-
-  getSelectableApps(): GioUnix.DesktopAppInfo[] {
-    const excluded = new Set(this.getExcludedApps());
-    return (Gio.AppInfo.get_all() as GioUnix.DesktopAppInfo[])
-      .filter((a) => {
-        const id = getAppId(a);
-        return a.should_show() && id !== "" && !excluded.has(id);
-      })
-      .sort((a, b) => {
-        return a.get_name().localeCompare(b.get_name());
-      });
-  }
-
-  // ── UI builders ─────────────────────────────────────────────────────────
 
   private buildGeneralGroup(): Adw.PreferencesGroup {
     const group = new Adw.PreferencesGroup();
@@ -105,7 +155,7 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
   }
 
   private buildSwitchRow(opts: {
-    key: string;
+    key: DeleteTriggerKey;
     title: string;
     subtitle: string;
   }): Adw.ActionRow {
@@ -114,12 +164,7 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
       subtitle: opts.subtitle,
     });
     const toggle = new Gtk.Switch({ valign: Gtk.Align.CENTER });
-    this.settings.bind(
-      opts.key,
-      toggle,
-      "active",
-      Gio.SettingsBindFlags.DEFAULT,
-    );
+    this.model.bindDeleteTrigger(opts.key, toggle, "active");
     row.add_suffix(toggle);
     return row;
   }
@@ -134,25 +179,20 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
         "Set the logging level for troubleshooting notification matching.",
     });
     const dropdown = new Gtk.DropDown({
-      model: Gtk.StringList.new(LOG_LEVELS),
+      model: Gtk.StringList.new([...PreferencesModel.LOG_LEVELS]),
       valign: Gtk.Align.CENTER,
     });
 
     const syncDropdown = () => {
-      const current = this.settings.get_string("log-level");
-      const idx = LOG_LEVELS.indexOf(current as LogLevel);
-      dropdown.set_selected(idx === -1 ? LOG_LEVELS.indexOf("info") : idx);
+      dropdown.set_selected(this.model.getLogLevelIndex());
     };
     syncDropdown();
-    const changedId = this.settings.connect("changed::log-level", syncDropdown);
-    dropdown.connect("notify::selected", () => {
-      this.settings.set_string(
-        "log-level",
-        LOG_LEVELS[dropdown.get_selected()] ?? "info",
-      );
+    const changedId = this.model.onLogLevelChanged(syncDropdown);
+    dropdown.connect("notify::selected", (dd: Gtk.DropDown) => {
+      this.model.setLogLevelIndex(dd.get_selected());
     });
     dropdown.connect("destroy", () => {
-      this.settings.disconnect(changedId);
+      this.model.disconnect(changedId);
     });
 
     row.add_suffix(dropdown);
@@ -175,10 +215,10 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
       css_classes: ["flat"],
       valign: Gtk.Align.CENTER,
     });
-    addButton.connect("clicked", () => {
-      const parent = addButton.get_root() as Gtk.Window | null;
+    addButton.connect("clicked", (btn: Gtk.Button) => {
+      const parent = btn.get_root() as Gtk.Window | null;
       this.openAppSelector(parent, (appId) => {
-        this.addExcludedApp(appId);
+        this.model.addExcludedApp(appId);
       });
     });
     group.set_header_suffix(addButton);
@@ -202,11 +242,11 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
     );
 
     this.rebuildExcludedAppsList(listBox);
-    const handlerId = this.settings.connect("changed::excluded-apps", () => {
+    const handlerId = this.model.onExcludedAppsChanged(() => {
       this.rebuildExcludedAppsList(listBox);
     });
     listBox.connect("destroy", () => {
-      this.settings.disconnect(handlerId);
+      this.model.disconnect(handlerId);
     });
 
     return listBox;
@@ -214,7 +254,7 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
 
   private rebuildExcludedAppsList(listBox: Gtk.ListBox): void {
     listBox.remove_all();
-    for (const appId of this.getExcludedApps()) {
+    for (const appId of this.model.getExcludedApps()) {
       listBox.append(this.buildExcludedAppRow(appId));
     }
   }
@@ -229,7 +269,7 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
       valign: Gtk.Align.CENTER,
     });
     removeButton.connect("clicked", () => {
-      this.removeExcludedApp(appId);
+      this.model.removeExcludedApp(appId);
     });
     row.add_suffix(removeButton);
 
@@ -248,7 +288,7 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
       margin_end: 8,
     });
 
-    for (const app of this.getSelectableApps()) {
+    for (const app of this.model.getSelectableApps()) {
       const appId = getAppId(app);
       const row = buildAppRow(app, appId, { activatable: true });
       row.connect("activated", () => onActivated(appId));
@@ -282,16 +322,13 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
       window.close();
     });
 
-    let query = "";
-    appList.set_filter_func((row) => {
-      if (query === "") return true;
-      const actionRow = row as Adw.ActionRow;
-      const title = actionRow.get_title().toLowerCase();
-      const subtitle = (actionRow.get_subtitle() ?? "").toLowerCase();
-      return title.includes(query) || subtitle.includes(query);
-    });
+    appList.set_filter_func((row) =>
+      rowMatchesQuery(
+        row as Adw.ActionRow,
+        search.get_text().toLowerCase().trim(),
+      ),
+    );
     search.connect("search-changed", () => {
-      query = search.get_text().toLowerCase().trim();
       appList.invalidate_filter();
     });
 

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -5,7 +5,7 @@ import Gtk from "gi://Gtk";
 import { ExtensionPreferences } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 import type { LogLevel } from "./extension.js";
 
-const LOG_LEVELS: LogLevel[] = ["debug", "info", "warn", "error"] as LogLevel[];
+const LOG_LEVELS: `${LogLevel}`[] = ["debug", "info", "warn", "error"];
 
 function getAppId(app: GioUnix.DesktopAppInfo): string {
   return (app.get_id() ?? "").replace(/\.desktop$/, "");
@@ -15,131 +15,62 @@ function lookupApp(appId: string): GioUnix.DesktopAppInfo | null {
   return GioUnix.DesktopAppInfo.new(`${appId}.desktop`);
 }
 
+function buildAppRow(
+  app: GioUnix.DesktopAppInfo | null | undefined,
+  appId: string,
+  extra: Partial<Adw.ActionRow.ConstructorProps> = {},
+): Adw.ActionRow {
+  const title = app?.get_name() ?? appId;
+  const row = new Adw.ActionRow({ ...extra, title, subtitle: appId });
+  const icon = app?.get_icon();
+  if (icon) {
+    const image = Gtk.Image.new_from_gicon(icon);
+    image.set_pixel_size(32);
+    row.add_prefix(image);
+  }
+  return row;
+}
+
 export default class JunkNotificationCleanerPreferences extends ExtensionPreferences {
+  private settings!: Gio.Settings;
+
   getPreferencesWidget() {
-    const settings = this.getSettings();
+    this.settings = this.getSettings();
 
     const page = new Adw.PreferencesPage();
     page.set_title("Settings");
     page.set_icon_name("preferences-system-symbolic");
 
-    const generalGroup = new Adw.PreferencesGroup();
-    generalGroup.set_title("General Settings");
-    page.add(generalGroup);
-
-    const focusRow = new Adw.ActionRow({
-      title: "Delete on Focus",
-      subtitle: "Delete notifications when an application window is focused.",
-    });
-    const focusSwitch = new Gtk.Switch({
-      active: settings.get_boolean("delete-on-focus"),
-      valign: Gtk.Align.CENTER,
-    });
-    settings.bind(
-      "delete-on-focus",
-      focusSwitch,
-      "active",
-      Gio.SettingsBindFlags.DEFAULT,
-    );
-    focusRow.add_suffix(focusSwitch);
-    generalGroup.add(focusRow);
-
-    const closeRow = new Adw.ActionRow({
-      title: "Delete on Close",
-      subtitle: "Delete notifications when an application window is closed.",
-    });
-    const closeSwitch = new Gtk.Switch({
-      active: settings.get_boolean("delete-on-close"),
-      valign: Gtk.Align.CENTER,
-    });
-    settings.bind(
-      "delete-on-close",
-      closeSwitch,
-      "active",
-      Gio.SettingsBindFlags.DEFAULT,
-    );
-    closeRow.add_suffix(closeSwitch);
-    generalGroup.add(closeRow);
-
-    const debugGroup = new Adw.PreferencesGroup();
-    debugGroup.set_title("Logging");
-    page.add(debugGroup);
-
-    const logLevelRow = new Adw.ActionRow({
-      title: "Log Level",
-      subtitle:
-        "Set the logging level for troubleshooting notification matching.",
-    });
-    const logLevelDropdown = new Gtk.DropDown({
-      model: Gtk.StringList.new(LOG_LEVELS),
-      valign: Gtk.Align.CENTER,
-    });
-
-    const currentLogLevel = settings.get_string("log-level") || "info";
-    const currentIndex = LOG_LEVELS.indexOf(currentLogLevel as LogLevel);
-    if (currentIndex !== -1) {
-      logLevelDropdown.set_selected(currentIndex);
-    }
-
-    logLevelDropdown.connect("notify::selected", () => {
-      const selectedIndex = logLevelDropdown.get_selected();
-      settings.set_string("log-level", LOG_LEVELS[selectedIndex]);
-    });
-
-    logLevelRow.add_suffix(logLevelDropdown);
-    debugGroup.add(logLevelRow);
-
-    const excludedGroup = new Adw.PreferencesGroup();
-    excludedGroup.set_title("Excluded Applications");
-    excludedGroup.set_description(
-      "Applications whose notifications will not be automatically deleted.",
-    );
-
-    const addButton = new Gtk.Button({
-      icon_name: "list-add-symbolic",
-      tooltip_text: "Add application",
-      css_classes: ["flat"],
-      valign: Gtk.Align.CENTER,
-    });
-    excludedGroup.set_header_suffix(addButton);
-    page.add(excludedGroup);
-
-    const listBox = new Gtk.ListBox({
-      selection_mode: Gtk.SelectionMode.NONE,
-      css_classes: ["boxed-list"],
-    });
-    excludedGroup.add(listBox);
-
-    const placeholder = new Gtk.Label({
-      label: "No excluded applications.",
-      css_classes: ["dim-label"],
-      margin_top: 12,
-      margin_bottom: 12,
-    });
-    listBox.set_placeholder(placeholder);
-
-    for (const appId of settings.get_strv("excluded-apps")) {
-      this.addExcludedAppRow(appId, listBox, settings);
-    }
-
-    addButton.connect("clicked", () => {
-      this.openAppSelector(
-        addButton.get_root() as Gtk.Window | null,
-        listBox,
-        settings,
-      );
-    });
+    page.add(this.buildGeneralGroup());
+    page.add(this.buildLoggingGroup());
+    page.add(this.buildExcludedAppsGroup());
 
     return page;
   }
 
-  openAppSelector(
-    parent: Gtk.Window | null,
-    listBox: Gtk.ListBox,
-    settings: Gio.Settings,
-  ): void {
-    const excluded = new Set(settings.get_strv("excluded-apps"));
-    const apps = (Gio.AppInfo.get_all() as GioUnix.DesktopAppInfo[])
+  // ── business logic ──────────────────────────────────────────────────────
+
+  getExcludedApps(): string[] {
+    return this.settings.get_strv("excluded-apps");
+  }
+
+  addExcludedApp(appId: string): void {
+    const current = this.getExcludedApps();
+    if (current.includes(appId)) return;
+    this.settings.set_strv("excluded-apps", [...current, appId]);
+  }
+
+  removeExcludedApp(appId: string): void {
+    const current = this.getExcludedApps();
+    this.settings.set_strv(
+      "excluded-apps",
+      current.filter((id) => id !== appId),
+    );
+  }
+
+  getSelectableApps(): GioUnix.DesktopAppInfo[] {
+    const excluded = new Set(this.getExcludedApps());
+    return (Gio.AppInfo.get_all() as GioUnix.DesktopAppInfo[])
       .filter((a) => {
         const id = getAppId(a);
         return a.should_show() && id !== "" && !excluded.has(id);
@@ -147,7 +78,190 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
       .sort((a, b) => {
         return a.get_name().localeCompare(b.get_name());
       });
+  }
 
+  // ── UI builders ─────────────────────────────────────────────────────────
+
+  private buildGeneralGroup(): Adw.PreferencesGroup {
+    const group = new Adw.PreferencesGroup();
+    group.set_title("General Settings");
+
+    group.add(
+      this.buildSwitchRow({
+        key: "delete-on-focus",
+        title: "Delete on Focus",
+        subtitle: "Delete notifications when an application window is focused.",
+      }),
+    );
+    group.add(
+      this.buildSwitchRow({
+        key: "delete-on-close",
+        title: "Delete on Close",
+        subtitle: "Delete notifications when an application window is closed.",
+      }),
+    );
+
+    return group;
+  }
+
+  private buildSwitchRow(opts: {
+    key: string;
+    title: string;
+    subtitle: string;
+  }): Adw.ActionRow {
+    const row = new Adw.ActionRow({
+      title: opts.title,
+      subtitle: opts.subtitle,
+    });
+    const toggle = new Gtk.Switch({ valign: Gtk.Align.CENTER });
+    this.settings.bind(
+      opts.key,
+      toggle,
+      "active",
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    row.add_suffix(toggle);
+    return row;
+  }
+
+  private buildLoggingGroup(): Adw.PreferencesGroup {
+    const group = new Adw.PreferencesGroup();
+    group.set_title("Logging");
+
+    const row = new Adw.ActionRow({
+      title: "Log Level",
+      subtitle:
+        "Set the logging level for troubleshooting notification matching.",
+    });
+    const dropdown = new Gtk.DropDown({
+      model: Gtk.StringList.new(LOG_LEVELS),
+      valign: Gtk.Align.CENTER,
+    });
+
+    const syncDropdown = () => {
+      const current = this.settings.get_string("log-level");
+      const idx = LOG_LEVELS.indexOf(current as LogLevel);
+      dropdown.set_selected(idx === -1 ? LOG_LEVELS.indexOf("info") : idx);
+    };
+    syncDropdown();
+    const changedId = this.settings.connect("changed::log-level", syncDropdown);
+    dropdown.connect("notify::selected", () => {
+      this.settings.set_string(
+        "log-level",
+        LOG_LEVELS[dropdown.get_selected()] ?? "info",
+      );
+    });
+    dropdown.connect("destroy", () => {
+      this.settings.disconnect(changedId);
+    });
+
+    row.add_suffix(dropdown);
+    group.add(row);
+    return group;
+  }
+
+  private buildExcludedAppsGroup(): Adw.PreferencesGroup {
+    const group = new Adw.PreferencesGroup();
+    group.set_title("Excluded Applications");
+    group.set_description(
+      "Applications whose notifications will not be automatically deleted.",
+    );
+
+    const listBox = this.buildExcludedAppsList();
+
+    const addButton = new Gtk.Button({
+      icon_name: "list-add-symbolic",
+      tooltip_text: "Add application",
+      css_classes: ["flat"],
+      valign: Gtk.Align.CENTER,
+    });
+    addButton.connect("clicked", () => {
+      const parent = addButton.get_root() as Gtk.Window | null;
+      this.openAppSelector(parent, (appId) => {
+        this.addExcludedApp(appId);
+      });
+    });
+    group.set_header_suffix(addButton);
+    group.add(listBox);
+
+    return group;
+  }
+
+  private buildExcludedAppsList(): Gtk.ListBox {
+    const listBox = new Gtk.ListBox({
+      selection_mode: Gtk.SelectionMode.NONE,
+      css_classes: ["boxed-list"],
+    });
+    listBox.set_placeholder(
+      new Gtk.Label({
+        label: "No excluded applications.",
+        css_classes: ["dim-label"],
+        margin_top: 12,
+        margin_bottom: 12,
+      }),
+    );
+
+    this.rebuildExcludedAppsList(listBox);
+    const handlerId = this.settings.connect("changed::excluded-apps", () => {
+      this.rebuildExcludedAppsList(listBox);
+    });
+    listBox.connect("destroy", () => {
+      this.settings.disconnect(handlerId);
+    });
+
+    return listBox;
+  }
+
+  private rebuildExcludedAppsList(listBox: Gtk.ListBox): void {
+    listBox.remove_all();
+    for (const appId of this.getExcludedApps()) {
+      listBox.append(this.buildExcludedAppRow(appId));
+    }
+  }
+
+  private buildExcludedAppRow(appId: string): Adw.ActionRow {
+    const row = buildAppRow(lookupApp(appId), appId);
+
+    const removeButton = new Gtk.Button({
+      icon_name: "user-trash-symbolic",
+      tooltip_text: "Remove",
+      css_classes: ["flat"],
+      valign: Gtk.Align.CENTER,
+    });
+    removeButton.connect("clicked", () => {
+      this.removeExcludedApp(appId);
+    });
+    row.add_suffix(removeButton);
+
+    return row;
+  }
+
+  private buildSelectableAppList(
+    onActivated: (appId: string) => unknown,
+  ): Gtk.ListBox {
+    const appList = new Gtk.ListBox({
+      selection_mode: Gtk.SelectionMode.NONE,
+      css_classes: ["boxed-list"],
+      margin_top: 8,
+      margin_bottom: 8,
+      margin_start: 8,
+      margin_end: 8,
+    });
+
+    for (const app of this.getSelectableApps()) {
+      const appId = getAppId(app);
+      const row = buildAppRow(app, appId, { activatable: true });
+      row.connect("activated", () => onActivated(appId));
+      appList.append(row);
+    }
+
+    return appList;
+  }
+
+  private openAppSelector(
+    parent: Gtk.Window | null,
+    onSelected: (appId: string) => void,
+  ): void {
     const window = new Adw.Window({
       title: "Add Excluded Application",
       modal: true,
@@ -160,17 +274,12 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
       placeholder_text: "Search applications",
       hexpand: true,
     });
-
     const headerBar = new Adw.HeaderBar();
     headerBar.set_title_widget(search);
 
-    const appList = new Gtk.ListBox({
-      selection_mode: Gtk.SelectionMode.NONE,
-      css_classes: ["boxed-list"],
-      margin_top: 8,
-      margin_bottom: 8,
-      margin_start: 8,
-      margin_end: 8,
+    const appList = this.buildSelectableAppList((appId) => {
+      onSelected(appId);
+      window.close();
     });
 
     let query = "";
@@ -181,76 +290,25 @@ export default class JunkNotificationCleanerPreferences extends ExtensionPrefere
       const subtitle = (actionRow.get_subtitle() ?? "").toLowerCase();
       return title.includes(query) || subtitle.includes(query);
     });
-
     search.connect("search-changed", () => {
       query = search.get_text().toLowerCase().trim();
       appList.invalidate_filter();
     });
 
-    for (const app of apps) {
-      const appId = getAppId(app);
-      const row = new Adw.ActionRow({
-        title: app.get_name(),
-        subtitle: appId,
-        activatable: true,
-      });
-      const icon = app.get_icon();
-      if (icon) {
-        const image = Gtk.Image.new_from_gicon(icon);
-        image.set_pixel_size(32);
-        row.add_prefix(image);
-      }
-      row.connect("activated", () => {
-        const current = settings.get_strv("excluded-apps");
-        if (!current.includes(appId)) {
-          settings.set_strv("excluded-apps", [...current, appId]);
-          this.addExcludedAppRow(appId, listBox, settings);
-        }
-        window.close();
-      });
-      appList.append(row);
-    }
+    const escController = new Gtk.ShortcutController();
+    escController.add_shortcut(
+      new Gtk.Shortcut({
+        trigger: Gtk.ShortcutTrigger.parse_string("Escape"),
+        action: Gtk.ShortcutAction.parse_string("action(window.close)"),
+      }),
+    );
+    window.add_controller(escController);
 
     const toolbarView = new Adw.ToolbarView();
     toolbarView.add_top_bar(headerBar);
     toolbarView.set_content(new Gtk.ScrolledWindow({ child: appList }));
     window.set_content(toolbarView);
     window.present();
-  }
-
-  addExcludedAppRow(
-    appId: string,
-    listBox: Gtk.ListBox,
-    settings: Gio.Settings,
-  ): void {
-    const app = lookupApp(appId);
-    const row = new Adw.ActionRow({
-      title: app?.get_name() ?? appId,
-      subtitle: appId,
-    });
-    const icon = app?.get_icon();
-    if (icon) {
-      const image = Gtk.Image.new_from_gicon(icon);
-      image.set_pixel_size(32);
-      row.add_prefix(image);
-    }
-
-    const removeButton = new Gtk.Button({
-      icon_name: "user-trash-symbolic",
-      tooltip_text: "Remove",
-      css_classes: ["flat"],
-      valign: Gtk.Align.CENTER,
-    });
-    removeButton.connect("clicked", () => {
-      const current = settings.get_strv("excluded-apps");
-      settings.set_strv(
-        "excluded-apps",
-        current.filter((id) => id !== appId),
-      );
-      listBox.remove(row);
-    });
-    row.add_suffix(removeButton);
-
-    listBox.append(row);
+    search.grab_focus();
   }
 }

--- a/test/extension.spec.ts
+++ b/test/extension.spec.ts
@@ -173,7 +173,7 @@ it.each([
     `[uuid][debug] Window(Title: 'Test', AppId: '${APP_ID}'): received focus`,
   );
   expect(log).toHaveBeenLastCalledWith(
-    `[uuid][info] Window(Title: 'Test', AppId: '${APP_ID}'): Source(Title: 'Test', PolicyId: '${APP_ID}'): removed notification`,
+    `[uuid][info] Window(Title: 'Test', AppId: '${APP_ID}'): Source(Title: 'Test', PolicyId: '${APP_ID}'): removed notification: (untitled notification)`,
   );
 });
 

--- a/test/extension.spec.ts
+++ b/test/extension.spec.ts
@@ -83,11 +83,16 @@ function makeWindow(overrides: WindowOverrides = {}): Meta.Window {
   } as WindowOverrides as Meta.Window;
 }
 
-function makeSource(overrides: Partial<Source> = {}, policyId = APP_ID) {
+function makeSource(
+  overrides: Partial<Source> = {},
+  policyId: string | null = APP_ID,
+) {
+  const policy =
+    policyId === null ? {} : new MockNotificationApplicationPolicy(policyId);
   return {
     title: "Test",
     notifications: [],
-    policy: new MockNotificationApplicationPolicy(policyId),
+    policy,
     ...overrides,
   } as Partial<Source> as Source;
 }
@@ -278,7 +283,7 @@ it.each([
     } as Partial<Notification> as Notification;
     const source = makeSource(
       { title: sourceTitle, notifications: [notification] },
-      "generic",
+      null,
     );
     const onFocusWindow = setupFocus({ sources: [source] });
     onFocusWindow({ focusWindow: makeWindow({ title: windowTitle }) });
@@ -370,7 +375,7 @@ function runHeuristic({ window, source }: HeuristicCase) {
   } as Partial<Notification> as Notification;
   const src = makeSource(
     { ...source, icon: stubIcon(source.icon), notifications: [notification] },
-    "generic",
+    null,
   );
   const onFocusWindow = setupFocus({ sources: [src] });
   onFocusWindow({ focusWindow: makeWindow(window) });
@@ -857,4 +862,64 @@ describe("heuristic match (non-app policy)", () => {
   ])("does not match: $description", (kase) => {
     expect(runHeuristic(kase)).not.toHaveBeenCalled();
   });
+
+  it("does not fall back to title when icon is set but does not match", () => {
+    expect(
+      runHeuristic({
+        description: "icon present, title would match if not gated",
+        window: {
+          gtkApplicationId: null,
+          get_sandboxed_app_id: () => null,
+          wmClass: "other",
+          title: "Slack",
+        },
+        source: {
+          title: "Slack",
+          icon: { to_string: () => "com.different.App" },
+        },
+      }),
+    ).not.toHaveBeenCalled();
+  });
+
+  it("does not match malformed snap icon paths", () => {
+    expect(
+      runHeuristic({
+        description: "snap path without trailing slash",
+        window: {
+          gtkApplicationId: null,
+          get_sandboxed_app_id: () => "firefox_firefox",
+          wmClass: "firefox",
+          title: "Firefox",
+        },
+        source: {
+          title: "Firefox",
+          icon: { to_string: () => "/snap/firefox" },
+        },
+      }),
+    ).not.toHaveBeenCalled();
+  });
+});
+
+it("clears notifications when policy id matches even if icon/title do not", () => {
+  const notification = {
+    destroy: vi.fn(),
+  } as Partial<Notification> as Notification;
+  const source = makeSource(
+    {
+      title: "Mismatched Title",
+      icon: stubIcon({ to_string: () => "com.different.App" }),
+      notifications: [notification],
+    },
+    APP_ID,
+  );
+  const onFocusWindow = setupFocus({ sources: [source] });
+  onFocusWindow({
+    focusWindow: makeWindow({
+      gtkApplicationId: "unrelated",
+      wmClass: "unrelated",
+      title: "unrelated",
+    }),
+  });
+
+  expect(notification.destroy).toHaveBeenCalledTimes(1);
 });

--- a/test/extension.spec.ts
+++ b/test/extension.spec.ts
@@ -19,7 +19,7 @@ Object.assign(global, {
 const settings = {
   get_boolean: vi.fn(),
   get_strv: vi.fn(),
-  get_string: vi.fn(),
+  get_enum: vi.fn(),
 };
 
 const windowTracker = {
@@ -78,13 +78,19 @@ interface WindowOverrides {
 function makeWindow(overrides: WindowOverrides = {}): Meta.Window {
   return {
     title: "Test",
+    wmClass: "",
+    gtkApplicationId: null,
     get_sandboxed_app_id: () => null,
     ...overrides,
   } as WindowOverrides as Meta.Window;
 }
 
+type SourceOverrides = Omit<Partial<Source>, "icon"> & {
+  icon?: Source["icon"] | null;
+};
+
 function makeSource(
-  overrides: Partial<Source> = {},
+  overrides: SourceOverrides = {},
   policyId: string | null = APP_ID,
 ) {
   const policy =
@@ -94,7 +100,7 @@ function makeSource(
     notifications: [],
     policy,
     ...overrides,
-  } as Partial<Source> as Source;
+  } as SourceOverrides as Source;
 }
 
 function setupFocus({
@@ -124,7 +130,7 @@ function setupClose({
 let extension: JunkNotificationCleaner;
 
 beforeEach(() => {
-  settings.get_string.mockReturnValue("debug");
+  settings.get_enum.mockReturnValue(0);
   windowTracker.get_window_app.mockReturnValue(makeApp());
   extension = new JunkNotificationCleaner({
     uuid: "uuid",
@@ -190,10 +196,10 @@ it.each([
   expect(messageTray.getSources).toHaveBeenCalledTimes(1);
   expect(log).toHaveBeenNthCalledWith(
     1,
-    `[uuid][debug] Window(Title: 'Test', AppId: '${APP_ID}'): received focus`,
+    `[uuid][debug] Window(Title: 'Test', AppId: '${APP_ID}', WmClass: 'com.app.test'): received focus`,
   );
   expect(log).toHaveBeenLastCalledWith(
-    `[uuid][info] Window(Title: 'Test', AppId: '${APP_ID}'): Source(Title: 'Test', PolicyId: '${APP_ID}'): removed notification: (untitled notification)`,
+    `[uuid][info] Window(Title: 'Test', AppId: '${APP_ID}', WmClass: 'com.app.test'): Source(Title: 'Test', PolicyId: '${APP_ID}'): removed notification: (untitled notification)`,
   );
 });
 
@@ -315,7 +321,7 @@ it.each([
 
   expect(messageTray.getSources).not.toHaveBeenCalled();
   expect(log).toHaveBeenLastCalledWith(
-    `[uuid][debug] Window(Title: 'Test', AppId: '${APP_ID}'): excluded by app id '${APP_ID}'`,
+    `[uuid][debug] Window(Title: 'Test', AppId: '${APP_ID}', WmClass: 'com.app.test'): excluded by app id '${APP_ID}'`,
   );
 });
 
@@ -898,6 +904,50 @@ describe("heuristic match (non-app policy)", () => {
       }),
     ).not.toHaveBeenCalled();
   });
+});
+
+it("does not heuristically match when policy id is present but mismatches", () => {
+  const notification = {
+    destroy: vi.fn(),
+  } as Partial<Notification> as Notification;
+  const source = makeSource(
+    {
+      title: "Slack",
+      icon: stubIcon({ to_string: () => "com.slack.Slack" }),
+      notifications: [notification],
+    },
+    "com.app.other",
+  );
+  const onFocusWindow = setupFocus({ sources: [source] });
+  onFocusWindow({
+    focusWindow: makeWindow({
+      gtkApplicationId: "com.slack.Slack",
+      wmClass: "slack",
+      title: "Slack",
+    }),
+  });
+
+  expect(notification.destroy).not.toHaveBeenCalled();
+});
+
+it("falls back to title when source.icon is null", () => {
+  const notification = {
+    destroy: vi.fn(),
+  } as Partial<Notification> as Notification;
+  const source = makeSource(
+    {
+      title: "Proton Mail Bridge",
+      icon: null,
+      notifications: [notification],
+    },
+    null,
+  );
+  const onFocusWindow = setupFocus({ sources: [source] });
+  onFocusWindow({
+    focusWindow: makeWindow({ title: "Proton Mail Bridge" }),
+  });
+
+  expect(notification.destroy).toHaveBeenCalledTimes(1);
 });
 
 it("clears notifications when policy id matches even if icon/title do not", () => {

--- a/test/extension.spec.ts
+++ b/test/extension.spec.ts
@@ -65,7 +65,22 @@ import { messageTray } from "resource:///org/gnome/shell/ui/main.js";
 const APP_ID = "com.app.test";
 
 function makeApp(id: string = APP_ID, name = "Test App") {
-  return { id, get_name: () => name } as unknown as Shell.App;
+  return { id, get_name: () => name } as Partial<Shell.App> as Shell.App;
+}
+
+interface WindowOverrides {
+  title?: string | null;
+  wmClass?: string;
+  gtkApplicationId?: string | null;
+  get_sandboxed_app_id?: () => string | null;
+}
+
+function makeWindow(overrides: WindowOverrides = {}): Meta.Window {
+  return {
+    title: "Test",
+    get_sandboxed_app_id: () => null,
+    ...overrides,
+  } as WindowOverrides as Meta.Window;
 }
 
 function makeSource(overrides: Partial<Source> = {}, policyId = APP_ID) {
@@ -163,7 +178,7 @@ it.each([
   const source = makeSource({ title: "Test", notifications: [notification] });
   const onFocusWindow = setupFocus({ excludedApps, sources: [source] });
   onFocusWindow({
-    focusWindow: { title: "Test", wmClass: "com.app.test" } as Meta.Window,
+    focusWindow: makeWindow({ wmClass: "com.app.test" }),
   });
 
   expect(notification.destroy).toHaveBeenCalledTimes(1);
@@ -186,14 +201,14 @@ it("should clear notifications for app on close", () => {
   onCloseWindow(
     {},
     {
-      metaWindow: { title: "Test" },
+      metaWindow: makeWindow(),
     },
   );
 
   expect(notification.destroy).toHaveBeenCalledTimes(1);
 });
 
-const focusWindowArg = { focusWindow: { title: "Test" } };
+const focusWindowArg = { focusWindow: makeWindow() };
 
 it("should not clear notifications for sources whose policy id does not match", () => {
   const appNotification = {
@@ -247,23 +262,26 @@ it("should skip transient notifications", () => {
 });
 
 it.each([
-  { name: "clear", title: "Test App", appName: "Test App", called: 1 },
-  { name: "skip", title: "Other", appName: "Test App", called: 0 },
-  { name: "skip", title: "", appName: "", called: 0 },
+  {
+    name: "clear",
+    sourceTitle: "Test App",
+    windowTitle: "Test App",
+    called: 1,
+  },
+  { name: "skip", sourceTitle: "Other", windowTitle: "Test App", called: 0 },
+  { name: "skip", sourceTitle: "", windowTitle: "", called: 0 },
 ])(
-  "should $name non-app-policy sources based on title matching the app name",
-  ({ title, appName, called }) => {
-    windowTracker.get_window_app.mockReturnValue(makeApp(APP_ID, appName));
+  "should $name non-app-policy sources based on title matching the window title",
+  ({ sourceTitle, windowTitle, called }) => {
     const notification = {
       destroy: vi.fn(),
     } as Partial<Notification> as Notification;
-    const source = {
-      title,
-      notifications: [notification],
-      policy: { id: "generic" },
-    } as unknown as Source;
+    const source = makeSource(
+      { title: sourceTitle, notifications: [notification] },
+      "generic",
+    );
     const onFocusWindow = setupFocus({ sources: [source] });
-    onFocusWindow(focusWindowArg);
+    onFocusWindow({ focusWindow: makeWindow({ title: windowTitle }) });
 
     expect(notification.destroy).toHaveBeenCalledTimes(called);
   },
@@ -287,7 +305,7 @@ it.each([
 ])("should not clear notifications for excluded apps", ({ excludedApps }) => {
   const onFocusWindow = setupFocus({ excludedApps });
   onFocusWindow({
-    focusWindow: { title: "Test", wmClass: "com.app.test" } as Meta.Window,
+    focusWindow: makeWindow({ wmClass: "com.app.test" }),
   });
 
   expect(messageTray.getSources).not.toHaveBeenCalled();
@@ -318,4 +336,525 @@ it("should not clear notifications for app on close if not enabled", () => {
 
   expect(settings.get_strv).not.toHaveBeenCalled();
   expect(log).not.toHaveBeenCalled();
+});
+
+// Heuristic matching: sources without NotificationApplicationPolicy fall
+// through to icon/title comparisons against the focused window.
+interface HeuristicCase {
+  description: string;
+  window: {
+    gtkApplicationId: string | null;
+    get_sandboxed_app_id: () => string | null;
+    wmClass: string;
+    title: string | null;
+  };
+  source: {
+    title: string;
+    icon: { to_string: () => string | null };
+  };
+}
+
+interface IconStub {
+  to_string: () => string | null;
+}
+
+function stubIcon(s: IconStub) {
+  return s as Partial<Source["icon"]> as Source["icon"];
+}
+
+const NO_ICON: IconStub = { to_string: () => null };
+
+function runHeuristic({ window, source }: HeuristicCase) {
+  const notification = {
+    destroy: vi.fn(),
+  } as Partial<Notification> as Notification;
+  const src = makeSource(
+    { ...source, icon: stubIcon(source.icon), notifications: [notification] },
+    "generic",
+  );
+  const onFocusWindow = setupFocus({ sources: [src] });
+  onFocusWindow({ focusWindow: makeWindow(window) });
+  return notification.destroy;
+}
+
+describe("heuristic match (non-app policy)", () => {
+  it.each<HeuristicCase>([
+    {
+      description: "gtkApplicationId and icon",
+      window: {
+        gtkApplicationId: "com.slack.Slack",
+        get_sandboxed_app_id: () => "com.slack.Slack",
+        wmClass: "slack",
+        title: "Slack",
+      },
+      source: { title: "Slack", icon: { to_string: () => "com.slack.Slack" } },
+    },
+    {
+      description: "gtkApplicationId and icon with different titles",
+      window: {
+        gtkApplicationId: "com.mitchellh.ghostty",
+        get_sandboxed_app_id: () => null,
+        wmClass: "ghostty",
+        title: "Ghostty",
+      },
+      source: {
+        title: "Terminal",
+        icon: { to_string: () => "com.mitchellh.ghostty" },
+      },
+    },
+    {
+      description: "sandboxed app id and icon",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => "org.mozilla.firefox",
+        wmClass: "firefox",
+        title: "Firefox",
+      },
+      source: {
+        title: "Browser",
+        icon: { to_string: () => "org.mozilla.firefox" },
+      },
+    },
+    {
+      description: "wmClass and icon",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "firefox",
+        title: "Mozilla Firefox",
+      },
+      source: { title: "Downloads", icon: { to_string: () => "firefox" } },
+    },
+    {
+      description: "exact title with null icon",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "protonmail-bridge",
+        title: "Proton Mail Bridge",
+      },
+      source: { title: "Proton Mail Bridge", icon: NO_ICON },
+    },
+    {
+      description: "title pattern extraction",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "cursor",
+        title: "isMatch.ts - junk-notification-cleaner - Cursor",
+      },
+      source: { title: "Cursor", icon: NO_ICON },
+    },
+    {
+      description: "gtkApplicationId and title",
+      window: {
+        gtkApplicationId: "org.gnome.TextEditor",
+        get_sandboxed_app_id: () => null,
+        wmClass: "text-editor",
+        title: "Text Editor",
+      },
+      source: {
+        title: "Text Editor",
+        icon: { to_string: () => "org.gnome.TextEditor" },
+      },
+    },
+    {
+      description: "title pattern with multiple dashes",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "code",
+        title: "main.ts - my-project-name - Visual Studio Code",
+      },
+      source: { title: "Visual Studio Code", icon: NO_ICON },
+    },
+    {
+      description: "title pattern with multiple dashes in app name",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "code",
+        title: "main.ts - my-project-name - app-name",
+      },
+      source: { title: "app-name", icon: NO_ICON },
+    },
+    {
+      description: "title pattern with pipe in app name",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "code",
+        title: "main.ts - my-project-name - app|name",
+      },
+      source: { title: "app|name", icon: NO_ICON },
+    },
+    {
+      description: "title pattern with pipe as separator",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "code",
+        title: "main.ts | my-project-name | app|name",
+      },
+      source: { title: "app|name", icon: NO_ICON },
+    },
+    {
+      description: "exact title when all other identifiers are null",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "",
+        title: "Simple App",
+      },
+      source: { title: "Simple App", icon: NO_ICON },
+    },
+    {
+      description: "wmClass icon match with different titles",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "telegram-desktop",
+        title: "Telegram",
+      },
+      source: {
+        title: "Different Title",
+        icon: { to_string: () => "telegram-desktop" },
+      },
+    },
+    {
+      description: "title pattern with single dash separator",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "browser",
+        title: "Document - Firefox",
+      },
+      source: { title: "Firefox", icon: NO_ICON },
+    },
+    {
+      description: "title pattern with extra whitespace in title",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "editor",
+        title: "file.txt - project - VSCode   App",
+      },
+      source: { title: "VSCode   App", icon: NO_ICON },
+    },
+    {
+      description: "gtkApplicationId with empty wmClass",
+      window: {
+        gtkApplicationId: "org.gnome.Calculator",
+        get_sandboxed_app_id: () => null,
+        wmClass: "",
+        title: "Calculator",
+      },
+      source: {
+        title: "Math App",
+        icon: { to_string: () => "org.gnome.Calculator" },
+      },
+    },
+    {
+      description: "sandboxed app id with empty gtkApplicationId",
+      window: {
+        gtkApplicationId: "",
+        get_sandboxed_app_id: () => "com.spotify.Client",
+        wmClass: "spotify",
+        title: "Spotify",
+      },
+      source: {
+        title: "Music Player",
+        icon: { to_string: () => "com.spotify.Client" },
+      },
+    },
+    {
+      description: "Firefox snap with file path icon",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => "firefox_firefox",
+        wmClass: "firefox_firefox",
+        title: "Notification Test — Mozilla Firefox",
+      },
+      source: {
+        title: "Firefox",
+        icon: { to_string: () => "/snap/firefox/6638/default256.png" },
+      },
+    },
+    {
+      description: "Thunderbird: source title equals wmClass",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "thunderbird",
+        title: "Calendario - Mozilla Thunderbird",
+      },
+      source: { title: "thunderbird", icon: NO_ICON },
+    },
+    {
+      description: "Discord snap: title_title matches sandboxed id",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => "discord_discord",
+        wmClass: "discord_discord",
+        title: "Amici - Discord",
+      },
+      source: { title: "discord", icon: NO_ICON },
+    },
+    {
+      description: "Discord composite channel title",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => "discord_discord",
+        wmClass: "discord_discord",
+        title: "#general | Character.AI - Discord",
+      },
+      source: { title: "Discord", icon: NO_ICON },
+    },
+    {
+      description: "Telegram snap with file path icon",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => "telegram-desktop_telegram-desktop",
+        wmClass: "telegram-desktop_telegram-desktop",
+        title: "Telegram",
+      },
+      source: {
+        title: "Telegram",
+        icon: {
+          to_string: () => "/snap/telegram-desktop/6767/meta/gui/icon.png",
+        },
+      },
+    },
+    {
+      description: "Empty window title with gtkApplicationId match",
+      window: {
+        gtkApplicationId: "com.mitchellh.ghostty",
+        get_sandboxed_app_id: () => null,
+        wmClass: "com.mitchellh.ghostty",
+        title: "",
+      },
+      source: {
+        title: "Ghostty",
+        icon: { to_string: () => "com.mitchellh.ghostty" },
+      },
+    },
+    {
+      description: "Google Chrome title pattern extraction",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "google-chrome",
+        title: "e2e - Google Chrome",
+      },
+      source: { title: "Google Chrome", icon: NO_ICON },
+    },
+    {
+      description: "xdg-desktop-portal-gnome icon match",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "xdg-desktop-portal-gnome",
+        title: "Compartición de pantalla",
+      },
+      source: {
+        title: "Screen Share",
+        icon: { to_string: () => "xdg-desktop-portal-gnome" },
+      },
+    },
+    {
+      description: "Slack flatpak with channel title",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => "com.slack.Slack",
+        wmClass: "com.slack.Slack",
+        title: "product-team-status (Canal) - Koda Health - Slack",
+      },
+      source: {
+        title: "Slack",
+        icon: { to_string: () => "com.slack.Slack" },
+      },
+    },
+  ])("matches: $description", (kase) => {
+    expect(runHeuristic(kase)).toHaveBeenCalledTimes(1);
+  });
+
+  it.each<HeuristicCase>([
+    {
+      description: "different applications with no matching criteria",
+      window: {
+        gtkApplicationId: "com.slack.Slack",
+        get_sandboxed_app_id: () => "com.slack.Slack",
+        wmClass: "slack",
+        title: "Slack",
+      },
+      source: {
+        title: "Discord",
+        icon: { to_string: () => "com.discord.Discord" },
+      },
+    },
+    {
+      description: "different identifiers",
+      window: {
+        gtkApplicationId: "com.example.App",
+        get_sandboxed_app_id: () => null,
+        wmClass: "example-app",
+        title: "Example App",
+      },
+      source: {
+        title: "Different App",
+        icon: { to_string: () => "com.different.App" },
+      },
+    },
+    {
+      description: "no matching identifiers or titles",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "unknown",
+        title: "Unknown Window",
+      },
+      source: { title: "Different Title", icon: NO_ICON },
+    },
+    {
+      description: "simple title without pattern format",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "some-app",
+        title: "Just a simple title without dashes",
+      },
+      source: { title: "Different App", icon: NO_ICON },
+    },
+    {
+      description: "title pattern but source does not match extracted part",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "editor",
+        title: "file.txt - MyProject - VSCode",
+      },
+      source: { title: "Atom", icon: NO_ICON },
+    },
+    {
+      description: "source icon mismatch",
+      window: {
+        gtkApplicationId: "com.app.One",
+        get_sandboxed_app_id: () => "com.app.One",
+        wmClass: "app-one",
+        title: "App One",
+      },
+      source: {
+        title: "App Two",
+        icon: { to_string: () => "com.app.Two" },
+      },
+    },
+    {
+      description: "empty source title and null icon",
+      window: {
+        gtkApplicationId: "com.example.App",
+        get_sandboxed_app_id: () => null,
+        wmClass: "example",
+        title: "Example",
+      },
+      source: { title: "", icon: NO_ICON },
+    },
+    {
+      description: "source icon returns empty string",
+      window: {
+        gtkApplicationId: "com.example.App",
+        get_sandboxed_app_id: () => null,
+        wmClass: "example",
+        title: "Example",
+      },
+      source: { title: "Different", icon: { to_string: () => "" } },
+    },
+    {
+      description: "title pattern with pipe as separator but wrong match",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "code",
+        title: "main.ts | my-project-name | app|name",
+      },
+      source: { title: "name", icon: NO_ICON },
+    },
+    {
+      description: "case-sensitive gtkApplicationId mismatch",
+      window: {
+        gtkApplicationId: "com.slack.Slack",
+        get_sandboxed_app_id: () => null,
+        wmClass: "slack",
+        title: "Slack",
+      },
+      source: {
+        title: "Different",
+        icon: { to_string: () => "com.slack.slack" },
+      },
+    },
+    {
+      description: "case-sensitive title mismatch",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "app",
+        title: "My Application",
+      },
+      source: { title: "my application", icon: NO_ICON },
+    },
+    {
+      description: "title pattern with only one part",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "app",
+        title: "SingleTitle",
+      },
+      source: { title: "DifferentApp", icon: NO_ICON },
+    },
+    {
+      description: "title pattern with empty extracted part",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "app",
+        title: "file.txt - project - ",
+      },
+      source: { title: "SomeApp", icon: NO_ICON },
+    },
+    {
+      description: "whitespace-only source title",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "app",
+        title: "Application",
+      },
+      source: { title: "   ", icon: NO_ICON },
+    },
+    {
+      description: "window title is empty string",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "app",
+        title: "",
+      },
+      source: { title: "SomeApp", icon: NO_ICON },
+    },
+    {
+      description: "window title is null",
+      window: {
+        gtkApplicationId: null,
+        get_sandboxed_app_id: () => null,
+        wmClass: "app",
+        title: null,
+      },
+      source: {
+        title: "SomeApp",
+        icon: { to_string: () => "com.example.App" },
+      },
+    },
+  ])("does not match: $description", (kase) => {
+    expect(runHeuristic(kase)).not.toHaveBeenCalled();
+  });
 });

--- a/test/extension.spec.ts
+++ b/test/extension.spec.ts
@@ -154,37 +154,28 @@ describe(JunkNotificationCleaner.prototype.disable.name, () => {
 });
 
 it.each([
-  {
-    wmClass: "com.app.test",
-    excludedApps: [],
-  },
-  {
-    wmClass: "com.app.test",
-    excludedApps: ["com.app.test1", "\\com\\.app\\.tes$"],
-  },
-])(
-  "should clear notifications for app on focus",
-  ({ wmClass, excludedApps }) => {
-    const notification = {
-      destroy: vi.fn(),
-    } as Partial<Notification> as Notification;
-    const source = makeSource({ title: "Test", notifications: [notification] });
-    const onFocusWindow = setupFocus({ excludedApps, sources: [source] });
-    onFocusWindow({
-      focusWindow: { title: "Test", wmClass } as Meta.Window,
-    });
+  { excludedApps: [] },
+  { excludedApps: ["com.app.other", "com.app.test2"] },
+])("should clear notifications for app on focus", ({ excludedApps }) => {
+  const notification = {
+    destroy: vi.fn(),
+  } as Partial<Notification> as Notification;
+  const source = makeSource({ title: "Test", notifications: [notification] });
+  const onFocusWindow = setupFocus({ excludedApps, sources: [source] });
+  onFocusWindow({
+    focusWindow: { title: "Test", wmClass: "com.app.test" } as Meta.Window,
+  });
 
-    expect(notification.destroy).toHaveBeenCalledTimes(1);
-    expect(messageTray.getSources).toHaveBeenCalledTimes(1);
-    expect(log).toHaveBeenNthCalledWith(
-      1,
-      `[uuid][debug] Window(Title: 'Test', WMClass: '${wmClass}', AppId: '${APP_ID}'): received focus`,
-    );
-    expect(log).toHaveBeenLastCalledWith(
-      `[uuid][info] Window(Title: 'Test', WMClass: '${wmClass}', AppId: '${APP_ID}'): Source(Title: 'Test', PolicyId: '${APP_ID}'): removed notification`,
-    );
-  },
-);
+  expect(notification.destroy).toHaveBeenCalledTimes(1);
+  expect(messageTray.getSources).toHaveBeenCalledTimes(1);
+  expect(log).toHaveBeenNthCalledWith(
+    1,
+    `[uuid][debug] Window(Title: 'Test', AppId: '${APP_ID}'): received focus`,
+  );
+  expect(log).toHaveBeenLastCalledWith(
+    `[uuid][info] Window(Title: 'Test', AppId: '${APP_ID}'): Source(Title: 'Test', PolicyId: '${APP_ID}'): removed notification`,
+  );
+});
 
 it("should clear notifications for app on close", () => {
   const notification = {
@@ -290,64 +281,27 @@ it("should bail out and log when no app is associated with the window", () => {
 });
 
 it.each([
-  {
-    wmClass: "com.app.test",
-    excludedApps: ["com.app.test"],
-  },
-  {
-    wmClass: "com.app.test",
-    excludedApps: ["com.app.test", "com.app.other"],
-  },
-  {
-    wmClass: "com.app.test",
-    excludedApps: ["com\\.app\\.test"],
-  },
-  {
-    wmClass: "com.app.test",
-    excludedApps: ["\\w+\\.\\w+\\.\\w+"],
-  },
-  {
-    wmClass: "jesus.christ",
-    excludedApps: ["^(jesus|christ)\\.(jesus|christ)$"],
-  },
-])(
-  "should not clear notifications for excluded apps",
-  ({ wmClass, excludedApps }) => {
-    const onFocusWindow = setupFocus({ excludedApps });
-    onFocusWindow({
-      focusWindow: { title: "Test", wmClass } as Meta.Window,
-    });
-
-    expect(messageTray.getSources).not.toHaveBeenCalled();
-    expect(log).toHaveBeenCalledTimes(2);
-    expect(log).toHaveBeenLastCalledWith(
-      `[uuid][debug] Window(Title: 'Test', WMClass: '${wmClass}', AppId: '${APP_ID}'): excluded by '${excludedApps[0]}'`,
-    );
-  },
-);
-
-it("should log warning and continue for invalid excluded app regex", () => {
-  const onFocusWindow = setupFocus({
-    excludedApps: ["[invalid", "com\\.app\\.test"],
-  });
+  { excludedApps: [APP_ID] },
+  { excludedApps: [APP_ID, "com.app.other"] },
+  { excludedApps: ["com.app.other", APP_ID] },
+])("should not clear notifications for excluded apps", ({ excludedApps }) => {
+  const onFocusWindow = setupFocus({ excludedApps });
   onFocusWindow({
     focusWindow: { title: "Test", wmClass: "com.app.test" } as Meta.Window,
   });
 
   expect(messageTray.getSources).not.toHaveBeenCalled();
-  expect(log).toHaveBeenNthCalledWith(
-    2,
-    `[uuid][warn] Window(Title: 'Test', WMClass: 'com.app.test', AppId: '${APP_ID}'): invalid regex '[invalid'`,
+  expect(log).toHaveBeenLastCalledWith(
+    `[uuid][debug] Window(Title: 'Test', AppId: '${APP_ID}'): excluded by app id '${APP_ID}'`,
   );
 });
 
-it("should treat null wmClass as no match against excluded apps", () => {
-  const onFocusWindow = setupFocus({ excludedApps: ["com\\.app\\.test"] });
-  onFocusWindow({
-    focusWindow: { title: "Test", wmClass: null } as unknown as Meta.Window,
-  });
+it("should match excluded apps after stripping .desktop suffix from app id", () => {
+  windowTracker.get_window_app.mockReturnValue(makeApp(`${APP_ID}.desktop`));
+  const onFocusWindow = setupFocus({ excludedApps: [APP_ID] });
+  onFocusWindow(focusWindowArg);
 
-  expect(messageTray.getSources).toHaveBeenCalledTimes(1);
+  expect(messageTray.getSources).not.toHaveBeenCalled();
 });
 
 it("should not clear notifications for app on focus if not enabled", () => {

--- a/test/extension.spec.ts
+++ b/test/extension.spec.ts
@@ -64,8 +64,8 @@ import { messageTray } from "resource:///org/gnome/shell/ui/main.js";
 
 const APP_ID = "com.app.test";
 
-function makeApp(id: string = APP_ID) {
-  return { id } as Shell.App;
+function makeApp(id: string = APP_ID, name = "Test App") {
+  return { id, get_name: () => name } as unknown as Shell.App;
 }
 
 function makeSource(overrides: Partial<Source> = {}, policyId = APP_ID) {
@@ -255,20 +255,28 @@ it("should skip transient notifications", () => {
   expect(persistent.destroy).toHaveBeenCalledTimes(1);
 });
 
-it("should skip sources whose policy is not a NotificationApplicationPolicy", () => {
-  const notification = {
-    destroy: vi.fn(),
-  } as Partial<Notification> as Notification;
-  const source = {
-    title: "Test",
-    notifications: [notification],
-    policy: { id: APP_ID },
-  } as unknown as Source;
-  const onFocusWindow = setupFocus({ sources: [source] });
-  onFocusWindow(focusWindowArg);
+it.each([
+  { name: "clear", title: "Test App", appName: "Test App", called: 1 },
+  { name: "skip", title: "Other", appName: "Test App", called: 0 },
+  { name: "skip", title: "", appName: "", called: 0 },
+])(
+  "should $name non-app-policy sources based on title matching the app name",
+  ({ title, appName, called }) => {
+    windowTracker.get_window_app.mockReturnValue(makeApp(APP_ID, appName));
+    const notification = {
+      destroy: vi.fn(),
+    } as Partial<Notification> as Notification;
+    const source = {
+      title,
+      notifications: [notification],
+      policy: { id: "generic" },
+    } as unknown as Source;
+    const onFocusWindow = setupFocus({ sources: [source] });
+    onFocusWindow(focusWindowArg);
 
-  expect(notification.destroy).not.toHaveBeenCalled();
-});
+    expect(notification.destroy).toHaveBeenCalledTimes(called);
+  },
+);
 
 it("should bail out and log when no app is associated with the window", () => {
   windowTracker.get_window_app.mockReturnValueOnce(null);


### PR DESCRIPTION
## Summary
- Restore the 0.3.4 icon/title matching heuristics as a fallback when a source has no `NotificationApplicationPolicy` (covers libnotify clients that don't send a desktop-entry hint: Slack channel messages, Discord, snap apps, etc.)
- Split matching into composable helpers: `matchByPolicyId`, `matchByIcon`, `matchBySnapIcon`, `matchByTitle`
- Add app exclusion by id with picker UI (drops regex matching)
- Refactor preferences: extract UI builders, wrap settings access in `PreferencesModel`, tighten gschema types
- Restore the full positive/negative test matrix from 0.3.4's `isMatch.spec.ts`, exercised through the extension's focus handler
- Add eslint rule banning `as unknown` double-casts; replace existing casts with typed helpers (`makeWindow`, `stubIcon`)
- Add Nix dev shell

## Test plan
- [ ] Verify notifications are cleared for native deb (Firefox, Thunderbird, Ghostty, Proton Mail Bridge)
- [ ] Verify notifications are cleared for flatpak (Slack, Discord)
- [ ] Verify notifications are cleared for snap (Firefox, Discord, Telegram, Slack)
- [ ] Verify app exclusion picker works
- [ ] Verify preferences UI loads and persists settings